### PR TITLE
chore: improve terminology consistency

### DIFF
--- a/src/Membership.sol
+++ b/src/Membership.sol
@@ -134,9 +134,9 @@ abstract contract MembershipUpgradeable is Initializable {
         internal
         onlyInitializing
     {
-        require(_maxTotalRateLimit >= maxMembershipRateLimit);
-        require(_maxMembershipRateLimit > minMembershipRateLimit); // FIXME: > or >=?
-        require(_minMembershipRateLimit > 0);
+        require(0 < _minMembershipRateLimit);
+        require(_minMembershipRateLimit <= _maxMembershipRateLimit); // FIXME: < or <=?
+        require(_maxMembershipRateLimit <= _maxTotalRateLimit);
         require(_activeStateDuration > 0); // FIXME: also _gracePeriodDuration > 0?
 
         priceCalculator = IPriceCalculator(_priceCalculator);

--- a/src/Membership.sol
+++ b/src/Membership.sol
@@ -177,7 +177,7 @@ abstract contract MembershipUpgradeable is Initializable {
     /// @dev Setup a new membership. If there are not enough remaining rate limit to acquire
     /// a new membership, it will attempt to erase existing expired memberships
     /// and reuse one of their slots
-    /// @param _sender holder of the membership. Generally `msg.sender` // FIXME: rename to holder?
+    /// @param _sender holder of the membership. Generally `msg.sender`
     /// @param _idCommitment idCommitment
     /// @param _rateLimit membership rate limit
     /// @param _token Address of the token used to acquire the membership
@@ -208,7 +208,7 @@ abstract contract MembershipUpgradeable is Initializable {
         (index, indexReused) = _getFreeIndex();
 
         memberships[_idCommitment] = MembershipInfo({
-            holder: _sender,
+            holder: _sender,  // FIXME: inconsistent with spec (keeper vs holder)
             gracePeriodStartTimestamp: block.timestamp + uint256(expirationTerm),
             gracePeriodDuration: gracePeriodDuration,
             token: _token,

--- a/src/Membership.sol
+++ b/src/Membership.sol
@@ -11,98 +11,100 @@ error InvalidRateLimit();
 
 // It's not possible to acquire the rate limit due to exceeding the expected limits
 // even after attempting to erase expired memberships
-error ExceedAvailableMaxRateLimitPerEpoch();
+error ExceededMaxTotalRateLimit();
 
-// This membership is not in grace period yet
+// This membership is not in grace period yet // FIXME: yet or also already?
 error NotInGracePeriod(uint256 idCommitment);
 
 // The sender is not the holder of the membership
-error NotHolder(uint256 idCommitment);
+error AttemptedExtensionByNonHolder(uint256 idCommitment);
 
-// This membership cannot be erased (either it is not expired or not in grace period and/or not the owner)
+// This membership cannot be erased (either it is not expired or not in grace period and/or not the owner) // FIXME:
+// separate into two errors?
 error CantEraseMembership(uint256 idCommitment);
 
 abstract contract MembershipUpgradeable is Initializable {
     using SafeERC20 for IERC20;
 
     /// @notice Address of the Price Calculator used to calculate the price of a new membership
-    IPriceCalculator public priceCalculator;
+    IPriceCalculator public priceCalculator; // FIXME: naming: price vs deposit?
 
-    /// @notice Maximum total rate limit of all memberships in the tree
+    /// @notice Maximum total rate limit of all memberships in the membership set (messages per epoch)
     uint32 public maxTotalRateLimit;
 
     /// @notice Maximum rate limit of one membership
-    uint32 public maxRateLimitPerMembership;
+    uint32 public maxMembershipRateLimit;
 
     /// @notice Minimum rate limit of one membership
-    uint32 public minRateLimitPerMembership;
+    uint32 public minMembershipRateLimit;
 
-    /// @notice Membership billing period
+    /// @notice Membership expiration term (T in the spec)
     uint32 public expirationTerm;
 
-    /// @notice Membership grace period
-    uint32 public gracePeriod;
+    /// @notice Membership grace period (G in the spec)
+    uint32 public gracePeriodDuration;
 
-    /// @notice balances available to withdraw
+    /// @notice deposit balances available to withdraw  // FIXME: are balances unavailable for withdrawal stored
+    /// elsewhere?
     mapping(address holder => mapping(address token => uint256 balance)) public balancesToWithdraw;
 
-    /// @notice Total rate limit of all memberships in the tree
-    uint256 public totalRateLimitPerEpoch;
+    /// @notice Total rate limit of all memberships in the membership set (messages per epoch)
+    uint256 public totalRateLimit;
 
     /// @notice List of registered memberships
-    mapping(uint256 idCommitment => MembershipInfo member) public memberships;
+    mapping(uint256 idCommitment => MembershipInfo membership) public memberships;
 
     /// @notice The index in the membership set for the next membership to be registered
     uint32 public nextFreeIndex;
 
-    /// @notice track available indices that are available due to expired memberships being removed
-    uint32[] public availableExpiredIndices;
+    /// @notice indices of expired memberships (can be erased)
+    uint32[] public availableExpiredMembershipsIndices;
 
     struct MembershipInfo {
-        /// @notice amount of the token used to acquire this membership
-        uint256 amount;
+        /// @notice amount of the token used to make the deposit to register this membership
+        uint256 depositAmount;
         /// @notice timestamp of when the grace period starts for this membership
-        uint256 gracePeriodStartDate;
+        uint256 gracePeriodStartTimestamp;
         /// @notice duration of the grace period
-        uint32 gracePeriod;
+        uint32 gracePeriodDuration;
         /// @notice the membership rate limit
         uint32 rateLimit;
-        /// @notice the index of the member in the membership set
+        /// @notice the index of the membership in the membership set
         uint32 index;
-        /// @notice address of the owner of this membership
+        /// @notice address of the holder of this membership
         address holder;
-        /// @notice token used to acquire this membership
+        /// @notice token used to make the deposit to register this membership
         address token;
     }
 
     /// @notice Emitted when a membership is erased due to having exceeded the grace period or the owner having chosen
-    /// to not extend it
-    /// @param idCommitment the idCommitment of the member
+    /// to not extend it // FIXME: expired or erased?
+    /// @param idCommitment the idCommitment of the membership
     /// @param membershipRateLimit the rate limit of this membership
-    /// @param index the index of the membership in the merkle tree
-    event MemberExpired(uint256 idCommitment, uint32 membershipRateLimit, uint32 index);
+    /// @param index the index of the membership in the membership set
+    event MembershipExpired(uint256 idCommitment, uint32 membershipRateLimit, uint32 index);
 
-    /// @notice Emitted when a membership in grace period is extended
-    /// @param idCommitment the idCommitment of the member
+    /// @notice Emitted when a membership in its grace period is extended
+    /// @param idCommitment the idCommitment of the membership
     /// @param membershipRateLimit the rate limit of this membership
-    /// @param index the index of the membership in the merkle tree
-    /// @param newExpirationDate the new expiration date of this membership
-    event MemberExtended(uint256 idCommitment, uint32 membershipRateLimit, uint32 index, uint256 newExpirationDate);
+    /// @param index the index of the membership in the membership set
+    /// @param newExpirationTime the new expiration timestamp of this membership
+    event MembershipExtended(uint256 idCommitment, uint32 membershipRateLimit, uint32 index, uint256 newExpirationTime);
 
     /// @dev contract initializer
     /// @param _priceCalculator Address of an instance of IPriceCalculator
-    /// @param _maxTotalRateLimit Maximum total rate limit of all memberships in the tree
-    /// @param _minRateLimitPerMembership Minimum rate limit of one membership
-    /// @param _maxRateLimitPerMembership Maximum rate limit of one membership
-    /// @param _expirationTerm Membership expiration term
-    /// @param _gracePeriod Membership grace period
+    /// @param _maxTotalRateLimit Maximum total rate limit of all memberships in the membership set
+    /// @param _minMembershipRateLimit Minimum rate limit of each membership
+    /// @param _maxMembershipRateLimit Maximum rate limit of each membership
+    /// @param _expirationTerm Expiration term of each membership
+    /// @param _gracePeriodDuration Grace period duration for each membership
     function __MembershipUpgradeable_init(
         address _priceCalculator,
         uint32 _maxTotalRateLimit,
-        uint32 _minRateLimitPerMembership,
-        uint32 _maxRateLimitPerMembership,
+        uint32 _minMembershipRateLimit,
+        uint32 _maxMembershipRateLimit,
         uint32 _expirationTerm,
-        uint32 _gracePeriod
+        uint32 _gracePeriodDuration
     )
         internal
         onlyInitializing
@@ -110,61 +112,61 @@ abstract contract MembershipUpgradeable is Initializable {
         __MembershipUpgradeable_init_unchained(
             _priceCalculator,
             _maxTotalRateLimit,
-            _minRateLimitPerMembership,
-            _maxRateLimitPerMembership,
+            _minMembershipRateLimit,
+            _maxMembershipRateLimit,
             _expirationTerm,
-            _gracePeriod
+            _gracePeriodDuration
         );
     }
 
     function __MembershipUpgradeable_init_unchained(
         address _priceCalculator,
         uint32 _maxTotalRateLimit,
-        uint32 _minRateLimitPerMembership,
-        uint32 _maxRateLimitPerMembership,
+        uint32 _minMembershipRateLimit,
+        uint32 _maxMembershipRateLimit,
         uint32 _expirationTerm,
-        uint32 _gracePeriod
+        uint32 _gracePeriodDuration
     )
         internal
         onlyInitializing
     {
-        require(_maxTotalRateLimit >= maxRateLimitPerMembership);
-        require(_maxRateLimitPerMembership > minRateLimitPerMembership);
-        require(_minRateLimitPerMembership > 0);
-        require(_expirationTerm > 0);
+        require(_maxTotalRateLimit >= maxMembershipRateLimit);
+        require(_maxMembershipRateLimit > minMembershipRateLimit); // FIXME: > or >=?
+        require(_minMembershipRateLimit > 0);
+        require(_expirationTerm > 0); // FIXME: also _gracePeriodDuration > 0?
 
         priceCalculator = IPriceCalculator(_priceCalculator);
         maxTotalRateLimit = _maxTotalRateLimit;
-        maxRateLimitPerMembership = _maxRateLimitPerMembership;
-        minRateLimitPerMembership = _minRateLimitPerMembership;
+        maxMembershipRateLimit = _maxMembershipRateLimit;
+        minMembershipRateLimit = _minMembershipRateLimit;
         expirationTerm = _expirationTerm;
-        gracePeriod = _gracePeriod;
+        gracePeriodDuration = _gracePeriodDuration;
     }
 
-    /// @notice Checks if a membership rate limit is valid. This does not take into account whether we the total
-    /// memberships have reached already the `maxTotalRateLimit`
+    /// @notice Checks if a membership rate limit is valid. This does not take into account whether the total
+    /// memberships have reached already the `maxTotalRateLimit` // FIXME: clarify
     /// @param membershipRateLimit The membership rate limit
     /// @return true if the membership rate limit is valid, false otherwise
     function isValidMembershipRateLimit(uint32 membershipRateLimit) external view returns (bool) {
-        return membershipRateLimit >= minRateLimitPerMembership && membershipRateLimit <= maxRateLimitPerMembership;
+        return membershipRateLimit >= minMembershipRateLimit && membershipRateLimit <= maxMembershipRateLimit;
     }
 
-    /// @dev acquire a membership and trasnfer the fees to the contract
+    /// @dev acquire a membership and trasnfer the fees to the contract // FIXME: fees == deposit?
     /// @param _sender address of the owner of the new membership
-    /// @param _idCommitment the idcommitment of the new membership
+    /// @param _idCommitment the idCommitment of the new membership
     /// @param _rateLimit the membership rate limit
-    /// @return index the index in the merkle tree
-    /// @return reuseIndex indicates whether a new leaf is being used or if using an existing leaf in the merkle tree
+    /// @return index the index in the membership set
+    /// @return indexReused indicates whether using a new Merkle tree leaf or an existing one
     function _acquireMembership(
         address _sender,
         uint256 _idCommitment,
         uint32 _rateLimit
     )
         internal
-        returns (uint32 index, bool reuseIndex)
+        returns (uint32 index, bool indexReused)
     {
         (address token, uint256 amount) = priceCalculator.calculate(_rateLimit);
-        (index, reuseIndex) = _setupMembershipDetails(_sender, _idCommitment, _rateLimit, token, amount);
+        (index, indexReused) = _setupMembershipDetails(_sender, _idCommitment, _rateLimit, token, amount);
         _transferFees(_sender, token, amount);
     }
 
@@ -173,147 +175,159 @@ abstract contract MembershipUpgradeable is Initializable {
     }
 
     /// @dev Setup a new membership. If there are not enough remaining rate limit to acquire
-    /// a new membership, it will attempt to erase existing memberships and reuse one of the
-    /// slots helds by the membership
-    /// @param _sender holder of the membership. Generally `msg.sender`
-    /// @param _idCommitment IDCommitment
+    /// a new membership, it will attempt to erase existing expired memberships
+    /// and reuse one of their slots
+    /// @param _sender holder of the membership. Generally `msg.sender` // FIXME: rename to holder?
+    /// @param _idCommitment idCommitment
     /// @param _rateLimit membership rate limit
     /// @param _token Address of the token used to acquire the membership
-    /// @param _amount Amount of the token used to acquire the membership
-    /// @return index membership index on the merkle tree
-    /// @return reuseIndex indicates whether the index returned was a reused slot on the tree or not
+    /// @param _depositAmount Amount of the tokens used to acquire the membership
+    /// @return index membership index in the membership set
+    /// @return indexReused indicates whether the index returned was a reused slot on the tree or not
     function _setupMembershipDetails(
         address _sender,
         uint256 _idCommitment,
         uint32 _rateLimit,
         address _token,
-        uint256 _amount
+        uint256 _depositAmount
     )
         internal
-        returns (uint32 index, bool reuseIndex)
+        returns (uint32 index, bool indexReused)
     {
-        if (_rateLimit < minRateLimitPerMembership || _rateLimit > maxRateLimitPerMembership) {
+        if (_rateLimit < minMembershipRateLimit || _rateLimit > maxMembershipRateLimit) {
             revert InvalidRateLimit();
         }
 
         // Determine if we exceed the total rate limit
-        totalRateLimitPerEpoch += _rateLimit;
-        if (totalRateLimitPerEpoch > maxTotalRateLimit) {
-            revert ExceedAvailableMaxRateLimitPerEpoch(); // List is empty or can't
+        totalRateLimit += _rateLimit;
+        if (totalRateLimit > maxTotalRateLimit) {
+            revert ExceededMaxTotalRateLimit();
         }
 
-        // Reuse available slots from previously removed expired memberships
-        (index, reuseIndex) = _nextIndex();
+        // Reuse available slots from previously removed (FIXME: clarify "removed") expired memberships
+        (index, indexReused) = _getFreeIndex();
 
         memberships[_idCommitment] = MembershipInfo({
             holder: _sender,
-            gracePeriodStartDate: block.timestamp + uint256(expirationTerm),
-            gracePeriod: gracePeriod,
+            gracePeriodStartTimestamp: block.timestamp + uint256(expirationTerm),
+            gracePeriodDuration: gracePeriodDuration,
             token: _token,
-            amount: _amount,
+            depositAmount: _depositAmount,
             rateLimit: _rateLimit,
             index: index
         });
     }
 
-    /// @dev reuse available slots from previously removed expired memberships
-    /// @return index index to use
-    /// @return reuseIndex indicates whether it is reusing an existing index, or using a new one
-    function _nextIndex() internal returns (uint32 index, bool reuseIndex) {
-        // Reuse available slots from previously removed expired memberships
-        uint256 arrLen = availableExpiredIndices.length;
+    /// @dev Get a free index (possibly from reusing a slot of an expired membership)
+    /// @return index index to be used for another membership registration
+    /// @return indexReused indicates whether index comes form reusing a slot of an expired membership
+    function _getFreeIndex() internal returns (uint32 index, bool indexReused) {
+        // Reuse available slots from previously removed (FIXME: clarify "removed") expired memberships
+        uint256 arrLen = availableExpiredMembershipsIndices.length;
         if (arrLen != 0) {
-            index = availableExpiredIndices[arrLen - 1];
-            availableExpiredIndices.pop();
-            reuseIndex = true;
+            index = availableExpiredMembershipsIndices[arrLen - 1];
+            availableExpiredMembershipsIndices.pop();
+            indexReused = true;
         } else {
             index = nextFreeIndex;
         }
     }
 
-    /// @dev Extend a membership expiration date. Membership must be on grace period
+    /// @dev Extend the expiration date of a grace-period membership
     /// @param _sender the address of the holder of the membership
     /// @param _idCommitment the idCommitment of the membership
     function _extendMembership(address _sender, uint256 _idCommitment) public {
-        MembershipInfo storage mdetails = memberships[_idCommitment];
+        MembershipInfo storage membership = memberships[_idCommitment];
 
-        if (!_isGracePeriod(mdetails.gracePeriodStartDate, mdetails.gracePeriod)) {
+        if (!_isInGracePeriodNow(membership.gracePeriodStartTimestamp, membership.gracePeriodDuration)) {
             revert NotInGracePeriod(_idCommitment);
         }
 
-        if (_sender != mdetails.holder) revert NotHolder(_idCommitment);
+        if (_sender != membership.holder) revert AttemptedExtensionByNonHolder(_idCommitment); // FIXME: turn into a
+            // modifier?
+        // FIXME: see spec: should extension depend on the current block.timestamp?
+        uint256 newGracePeriodStartTimestamp = block.timestamp + uint256(expirationTerm);
 
-        uint256 gracePeriodStartDate = block.timestamp + uint256(expirationTerm);
+        membership.gracePeriodStartTimestamp = newGracePeriodStartTimestamp;
+        membership.gracePeriodDuration = gracePeriodDuration; // FIXME: redundant: just assigns old value
 
-        mdetails.gracePeriodStartDate = gracePeriodStartDate;
-        mdetails.gracePeriod = gracePeriod;
-
-        emit MemberExtended(_idCommitment, mdetails.rateLimit, mdetails.index, gracePeriodStartDate);
+        emit MembershipExtended(
+            _idCommitment, membership.rateLimit, membership.index, membership.gracePeriodStartTimestamp
+        );
     }
 
-    /// @dev Determine whether a timestamp is considered to be expired or not after exceeding the grace period
-    /// @param _gracePeriodStartDate timestamp in which the grace period starts
-    /// @param _gracePeriod duration of the grace period
-    function _isExpired(uint256 _gracePeriodStartDate, uint32 _gracePeriod) internal view returns (bool) {
-        return block.timestamp > _gracePeriodStartDate + uint256(_gracePeriod);
+    /// @dev Determine whether a grace period has passed (the membership is expired)
+    /// @param _gracePeriodStartTimestamp timestamp in which the grace period starts
+    /// @param _gracePeriodDuration duration of the grace period
+    function _isExpired(uint256 _gracePeriodStartTimestamp, uint32 _gracePeriodDuration) internal view returns (bool) {
+        return block.timestamp > _gracePeriodStartTimestamp + uint256(_gracePeriodDuration);
     }
 
-    /// @notice Determine if a membership is expired (has exceeded the grace period)
+    /// @notice Determine if a membership is expired
     /// @param _idCommitment the idCommitment of the membership
     function isExpired(uint256 _idCommitment) public view returns (bool) {
-        MembershipInfo memory m = memberships[_idCommitment];
-        return _isExpired(m.gracePeriodStartDate, m.gracePeriod);
+        MembershipInfo memory membership = memberships[_idCommitment];
+        return _isExpired(membership.gracePeriodStartTimestamp, membership.gracePeriodDuration);
     }
 
     /// @notice Returns the timestamp on which a membership can be considered expired
     /// @param _idCommitment the idCommitment of the membership
-    function expirationDate(uint256 _idCommitment) public view returns (uint256) {
-        MembershipInfo memory m = memberships[_idCommitment];
-        return m.gracePeriodStartDate + uint256(m.gracePeriod) + 1;
+    function membershipExpirationTimestamp(uint256 _idCommitment) public view returns (uint256) {
+        MembershipInfo memory membership = memberships[_idCommitment];
+        return membership.gracePeriodStartTimestamp + uint256(membership.gracePeriodDuration) + 1;
     }
 
-    /// @dev Determine whether a timestamp is considered to be in grace period or not
-    /// @param _gracePeriodStartDate timestamp in which the grace period starts
-    /// @param _gracePeriod duration of the grace period
-    function _isGracePeriod(uint256 _gracePeriodStartDate, uint32 _gracePeriod) internal view returns (bool) {
+    /// @dev Determine whether the current timestamp is in a given grace period
+    /// @param _gracePeriodStartTimestamp timestamp in which the grace period starts
+    /// @param _gracePeriodDuration duration of the grace period
+    function _isInGracePeriodNow(
+        uint256 _gracePeriodStartTimestamp,
+        uint32 _gracePeriodDuration
+    )
+        internal
+        view
+        returns (bool)
+    {
         uint256 blockTimestamp = block.timestamp;
-        return
-            blockTimestamp >= _gracePeriodStartDate && blockTimestamp <= _gracePeriodStartDate + uint256(_gracePeriod);
+        return blockTimestamp >= _gracePeriodStartTimestamp
+            && blockTimestamp <= _gracePeriodStartTimestamp + uint256(_gracePeriodDuration);
     }
 
-    /// @notice Determine if a membership is in grace period
+    /// @notice Determine if a membership is in grace period now
     /// @param _idCommitment the idCommitment of the membership
-    function isGracePeriod(uint256 _idCommitment) public view returns (bool) {
-        MembershipInfo memory m = memberships[_idCommitment];
-        return _isGracePeriod(m.gracePeriodStartDate, m.gracePeriod);
+    function isInGracePeriodNow(uint256 _idCommitment) public view returns (bool) {
+        MembershipInfo memory membership = memberships[_idCommitment];
+        return _isInGracePeriodNow(membership.gracePeriodStartTimestamp, membership.gracePeriodDuration);
     }
 
-    /// @dev Erase expired memberships or owned memberships in grace period.
+    /// @dev Erase expired memberships or owned grace-period memberships.
     /// @param _sender address of the sender of transaction (will be used to check memberships in grace period)
-    /// @param _idCommitment IDCommitment of the membership to erase
-    function _eraseMembership(address _sender, uint256 _idCommitment, MembershipInfo memory _mdetails) internal {
-        bool membershipExpired = _isExpired(_mdetails.gracePeriodStartDate, _mdetails.gracePeriod);
-        bool isGracePeriodAndOwned =
-            _isGracePeriod(_mdetails.gracePeriodStartDate, _mdetails.gracePeriod) && _mdetails.holder == _sender;
+    /// @param _idCommitment idCommitment of the membership to erase
+    function _eraseMembership(address _sender, uint256 _idCommitment, MembershipInfo memory _membership) internal {
+        bool membershipExpired = _isExpired(_membership.gracePeriodStartTimestamp, _membership.gracePeriodDuration);
+        bool isInGracePeriodAndOwned = // FIXME: separate into two checks? cf. short-circuit
+        _isInGracePeriodNow(_membership.gracePeriodStartTimestamp, _membership.gracePeriodDuration)
+            && _membership.holder == _sender;
+        // FIXME: we already had a non-holder check: reuse it here as a modifier
+        if (!membershipExpired && !isInGracePeriodAndOwned) revert CantEraseMembership(_idCommitment);
 
-        if (!membershipExpired && !isGracePeriodAndOwned) revert CantEraseMembership(_idCommitment);
-
-        emit MemberExpired(_idCommitment, _mdetails.rateLimit, _mdetails.index);
+        emit MembershipExpired(_idCommitment, _membership.rateLimit, _membership.index);
 
         // Move balance from expired membership to holder balance
-        balancesToWithdraw[_mdetails.holder][_mdetails.token] += _mdetails.amount;
+        balancesToWithdraw[_membership.holder][_membership.token] += _membership.depositAmount;
 
         // Deduct the expired membership rate limit
-        totalRateLimitPerEpoch -= _mdetails.rateLimit;
+        totalRateLimit -= _membership.rateLimit;
 
-        availableExpiredIndices.push(_mdetails.index);
+        // Note: the Merkle tree data will be erased lazily later  // FIXME: when?
+        availableExpiredMembershipsIndices.push(_membership.index);
 
         delete memberships[_idCommitment];
     }
 
     /// @dev Withdraw any available balance in tokens after a membership is erased.
     /// @param _sender the address of the owner of the tokens
-    /// @param _token the address of the token to withdraw.
+    /// @param _token the address of the token to withdraw
     function _withdraw(address _sender, address _token) internal {
         require(_token != address(0), "ETH is not allowed");
 

--- a/src/Membership.sol
+++ b/src/Membership.sol
@@ -29,7 +29,7 @@ abstract contract MembershipUpgradeable is Initializable {
     IPriceCalculator public priceCalculator;
 
     /// @notice Maximum total rate limit of all memberships in the tree
-    uint32 public maxTotalRateLimitPerEpoch;
+    uint32 public maxTotalRateLimit;
 
     /// @notice Maximum rate limit of one membership
     uint32 public maxRateLimitPerMembership;
@@ -50,10 +50,10 @@ abstract contract MembershipUpgradeable is Initializable {
     uint256 public totalRateLimitPerEpoch;
 
     /// @notice List of registered memberships
-    mapping(uint256 idCommitment => MembershipInfo member) public members;
+    mapping(uint256 idCommitment => MembershipInfo member) public memberships;
 
-    /// @notice The index on the merkle tree for the next member to be registered
-    uint32 public nextCommitmentIndex;
+    /// @notice The index in the membership set for the next membership to be registered
+    uint32 public nextFreeIndex;
 
     /// @notice track available indices that are available due to expired memberships being removed
     uint32[] public availableExpiredIndices;
@@ -65,9 +65,9 @@ abstract contract MembershipUpgradeable is Initializable {
         uint256 gracePeriodStartDate;
         /// @notice duration of the grace period
         uint32 gracePeriod;
-        /// @notice the user message limit of each member
-        uint32 userMessageLimit;
-        /// @notice the index of the member in the set
+        /// @notice the membership rate limit
+        uint32 rateLimit;
+        /// @notice the index of the member in the membership set
         uint32 index;
         /// @notice address of the owner of this membership
         address holder;
@@ -78,27 +78,27 @@ abstract contract MembershipUpgradeable is Initializable {
     /// @notice Emitted when a membership is erased due to having exceeded the grace period or the owner having chosen
     /// to not extend it
     /// @param idCommitment the idCommitment of the member
-    /// @param userMessageLimit the rate limit of this membership
+    /// @param membershipRateLimit the rate limit of this membership
     /// @param index the index of the membership in the merkle tree
-    event MemberExpired(uint256 idCommitment, uint32 userMessageLimit, uint32 index);
+    event MemberExpired(uint256 idCommitment, uint32 membershipRateLimit, uint32 index);
 
     /// @notice Emitted when a membership in grace period is extended
     /// @param idCommitment the idCommitment of the member
-    /// @param userMessageLimit the rate limit of this membership
+    /// @param membershipRateLimit the rate limit of this membership
     /// @param index the index of the membership in the merkle tree
     /// @param newExpirationDate the new expiration date of this membership
-    event MemberExtended(uint256 idCommitment, uint32 userMessageLimit, uint32 index, uint256 newExpirationDate);
+    event MemberExtended(uint256 idCommitment, uint32 membershipRateLimit, uint32 index, uint256 newExpirationDate);
 
     /// @dev contract initializer
     /// @param _priceCalculator Address of an instance of IPriceCalculator
-    /// @param _maxTotalRateLimitPerEpoch Maximum total rate limit of all memberships in the tree
+    /// @param _maxTotalRateLimit Maximum total rate limit of all memberships in the tree
     /// @param _minRateLimitPerMembership Minimum rate limit of one membership
     /// @param _maxRateLimitPerMembership Maximum rate limit of one membership
     /// @param _expirationTerm Membership expiration term
     /// @param _gracePeriod Membership grace period
     function __MembershipUpgradeable_init(
         address _priceCalculator,
-        uint32 _maxTotalRateLimitPerEpoch,
+        uint32 _maxTotalRateLimit,
         uint32 _minRateLimitPerMembership,
         uint32 _maxRateLimitPerMembership,
         uint32 _expirationTerm,
@@ -109,7 +109,7 @@ abstract contract MembershipUpgradeable is Initializable {
     {
         __MembershipUpgradeable_init_unchained(
             _priceCalculator,
-            _maxTotalRateLimitPerEpoch,
+            _maxTotalRateLimit,
             _minRateLimitPerMembership,
             _maxRateLimitPerMembership,
             _expirationTerm,
@@ -119,7 +119,7 @@ abstract contract MembershipUpgradeable is Initializable {
 
     function __MembershipUpgradeable_init_unchained(
         address _priceCalculator,
-        uint32 _maxTotalRateLimitPerEpoch,
+        uint32 _maxTotalRateLimit,
         uint32 _minRateLimitPerMembership,
         uint32 _maxRateLimitPerMembership,
         uint32 _expirationTerm,
@@ -128,43 +128,43 @@ abstract contract MembershipUpgradeable is Initializable {
         internal
         onlyInitializing
     {
-        require(_maxTotalRateLimitPerEpoch >= maxRateLimitPerMembership);
+        require(_maxTotalRateLimit >= maxRateLimitPerMembership);
         require(_maxRateLimitPerMembership > minRateLimitPerMembership);
         require(_minRateLimitPerMembership > 0);
         require(_expirationTerm > 0);
 
         priceCalculator = IPriceCalculator(_priceCalculator);
-        maxTotalRateLimitPerEpoch = _maxTotalRateLimitPerEpoch;
+        maxTotalRateLimit = _maxTotalRateLimit;
         maxRateLimitPerMembership = _maxRateLimitPerMembership;
         minRateLimitPerMembership = _minRateLimitPerMembership;
         expirationTerm = _expirationTerm;
         gracePeriod = _gracePeriod;
     }
 
-    /// @notice Checks if a user message limit is valid. This does not take into account whether we the total
-    /// memberships have reached already the `maxTotalRateLimitPerEpoch`
-    /// @param userMessageLimit The user message limit
-    /// @return true if the user message limit is valid, false otherwise
-    function isValidUserMessageLimit(uint32 userMessageLimit) external view returns (bool) {
-        return userMessageLimit >= minRateLimitPerMembership && userMessageLimit <= maxRateLimitPerMembership;
+    /// @notice Checks if a membership rate limit is valid. This does not take into account whether we the total
+    /// memberships have reached already the `maxTotalRateLimit`
+    /// @param membershipRateLimit The membership rate limit
+    /// @return true if the membership rate limit is valid, false otherwise
+    function isValidMembershipRateLimit(uint32 membershipRateLimit) external view returns (bool) {
+        return membershipRateLimit >= minRateLimitPerMembership && membershipRateLimit <= maxRateLimitPerMembership;
     }
 
     /// @dev acquire a membership and trasnfer the fees to the contract
     /// @param _sender address of the owner of the new membership
     /// @param _idCommitment the idcommitment of the new membership
-    /// @param _rateLimit the user message limit
+    /// @param _rateLimit the membership rate limit
     /// @return index the index in the merkle tree
-    /// @return reusedIndex indicates whether a new leaf is being used or if using an existing leaf in the merkle tree
+    /// @return reuseIndex indicates whether a new leaf is being used or if using an existing leaf in the merkle tree
     function _acquireMembership(
         address _sender,
         uint256 _idCommitment,
         uint32 _rateLimit
     )
         internal
-        returns (uint32 index, bool reusedIndex)
+        returns (uint32 index, bool reuseIndex)
     {
         (address token, uint256 amount) = priceCalculator.calculate(_rateLimit);
-        (index, reusedIndex) = _setupMembershipDetails(_sender, _idCommitment, _rateLimit, token, amount);
+        (index, reuseIndex) = _setupMembershipDetails(_sender, _idCommitment, _rateLimit, token, amount);
         _transferFees(_sender, token, amount);
     }
 
@@ -177,11 +177,11 @@ abstract contract MembershipUpgradeable is Initializable {
     /// slots helds by the membership
     /// @param _sender holder of the membership. Generally `msg.sender`
     /// @param _idCommitment IDCommitment
-    /// @param _rateLimit User message limit
+    /// @param _rateLimit membership rate limit
     /// @param _token Address of the token used to acquire the membership
     /// @param _amount Amount of the token used to acquire the membership
     /// @return index membership index on the merkle tree
-    /// @return reusedIndex indicates whether the index returned was a reused slot on the tree or not
+    /// @return reuseIndex indicates whether the index returned was a reused slot on the tree or not
     function _setupMembershipDetails(
         address _sender,
         uint256 _idCommitment,
@@ -190,7 +190,7 @@ abstract contract MembershipUpgradeable is Initializable {
         uint256 _amount
     )
         internal
-        returns (uint32 index, bool reusedIndex)
+        returns (uint32 index, bool reuseIndex)
     {
         if (_rateLimit < minRateLimitPerMembership || _rateLimit > maxRateLimitPerMembership) {
             revert InvalidRateLimit();
@@ -198,36 +198,36 @@ abstract contract MembershipUpgradeable is Initializable {
 
         // Determine if we exceed the total rate limit
         totalRateLimitPerEpoch += _rateLimit;
-        if (totalRateLimitPerEpoch > maxTotalRateLimitPerEpoch) {
+        if (totalRateLimitPerEpoch > maxTotalRateLimit) {
             revert ExceedAvailableMaxRateLimitPerEpoch(); // List is empty or can't
         }
 
         // Reuse available slots from previously removed expired memberships
-        (index, reusedIndex) = _nextIndex();
+        (index, reuseIndex) = _nextIndex();
 
-        members[_idCommitment] = MembershipInfo({
+        memberships[_idCommitment] = MembershipInfo({
             holder: _sender,
             gracePeriodStartDate: block.timestamp + uint256(expirationTerm),
             gracePeriod: gracePeriod,
             token: _token,
             amount: _amount,
-            userMessageLimit: _rateLimit,
+            rateLimit: _rateLimit,
             index: index
         });
     }
 
     /// @dev reuse available slots from previously removed expired memberships
     /// @return index index to use
-    /// @return reusedIndex indicates whether it is reusing an existing index, or using a new one
-    function _nextIndex() internal returns (uint32 index, bool reusedIndex) {
+    /// @return reuseIndex indicates whether it is reusing an existing index, or using a new one
+    function _nextIndex() internal returns (uint32 index, bool reuseIndex) {
         // Reuse available slots from previously removed expired memberships
         uint256 arrLen = availableExpiredIndices.length;
         if (arrLen != 0) {
             index = availableExpiredIndices[arrLen - 1];
             availableExpiredIndices.pop();
-            reusedIndex = true;
+            reuseIndex = true;
         } else {
-            index = nextCommitmentIndex;
+            index = nextFreeIndex;
         }
     }
 
@@ -235,7 +235,7 @@ abstract contract MembershipUpgradeable is Initializable {
     /// @param _sender the address of the holder of the membership
     /// @param _idCommitment the idCommitment of the membership
     function _extendMembership(address _sender, uint256 _idCommitment) public {
-        MembershipInfo storage mdetails = members[_idCommitment];
+        MembershipInfo storage mdetails = memberships[_idCommitment];
 
         if (!_isGracePeriod(mdetails.gracePeriodStartDate, mdetails.gracePeriod)) {
             revert NotInGracePeriod(_idCommitment);
@@ -248,7 +248,7 @@ abstract contract MembershipUpgradeable is Initializable {
         mdetails.gracePeriodStartDate = gracePeriodStartDate;
         mdetails.gracePeriod = gracePeriod;
 
-        emit MemberExtended(_idCommitment, mdetails.userMessageLimit, mdetails.index, gracePeriodStartDate);
+        emit MemberExtended(_idCommitment, mdetails.rateLimit, mdetails.index, gracePeriodStartDate);
     }
 
     /// @dev Determine whether a timestamp is considered to be expired or not after exceeding the grace period
@@ -261,14 +261,14 @@ abstract contract MembershipUpgradeable is Initializable {
     /// @notice Determine if a membership is expired (has exceeded the grace period)
     /// @param _idCommitment the idCommitment of the membership
     function isExpired(uint256 _idCommitment) public view returns (bool) {
-        MembershipInfo memory m = members[_idCommitment];
+        MembershipInfo memory m = memberships[_idCommitment];
         return _isExpired(m.gracePeriodStartDate, m.gracePeriod);
     }
 
     /// @notice Returns the timestamp on which a membership can be considered expired
     /// @param _idCommitment the idCommitment of the membership
     function expirationDate(uint256 _idCommitment) public view returns (uint256) {
-        MembershipInfo memory m = members[_idCommitment];
+        MembershipInfo memory m = memberships[_idCommitment];
         return m.gracePeriodStartDate + uint256(m.gracePeriod) + 1;
     }
 
@@ -284,11 +284,11 @@ abstract contract MembershipUpgradeable is Initializable {
     /// @notice Determine if a membership is in grace period
     /// @param _idCommitment the idCommitment of the membership
     function isGracePeriod(uint256 _idCommitment) public view returns (bool) {
-        MembershipInfo memory m = members[_idCommitment];
+        MembershipInfo memory m = memberships[_idCommitment];
         return _isGracePeriod(m.gracePeriodStartDate, m.gracePeriod);
     }
 
-    /// @dev Remove expired memberships or owned memberships in grace period.
+    /// @dev Erase expired memberships or owned memberships in grace period.
     /// @param _sender address of the sender of transaction (will be used to check memberships in grace period)
     /// @param _idCommitment IDCommitment of the membership to erase
     function _eraseMembership(address _sender, uint256 _idCommitment, MembershipInfo memory _mdetails) internal {
@@ -298,17 +298,17 @@ abstract contract MembershipUpgradeable is Initializable {
 
         if (!membershipExpired && !isGracePeriodAndOwned) revert CantEraseMembership(_idCommitment);
 
-        emit MemberExpired(_idCommitment, _mdetails.userMessageLimit, _mdetails.index);
+        emit MemberExpired(_idCommitment, _mdetails.rateLimit, _mdetails.index);
 
         // Move balance from expired membership to holder balance
         balancesToWithdraw[_mdetails.holder][_mdetails.token] += _mdetails.amount;
 
         // Deduct the expired membership rate limit
-        totalRateLimitPerEpoch -= _mdetails.userMessageLimit;
+        totalRateLimitPerEpoch -= _mdetails.rateLimit;
 
         availableExpiredIndices.push(_mdetails.index);
 
-        delete members[_idCommitment];
+        delete memberships[_idCommitment];
     }
 
     /// @dev Withdraw any available balance in tokens after a membership is erased.

--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -64,14 +64,14 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     /// @param _maxTotalRateLimit Maximum total rate limit of all memberships FIXME: clarify: excl expired?
     /// @param _minMembershipRateLimit Minimum rate limit of one membership
     /// @param _maxMembershipRateLimit Maximum rate limit of one membership
-    /// @param _expirationTerm Membership expiration term
+    /// @param _activeStateDuration Membership expiration term
     /// @param _gracePeriod Membership grace period
     function initialize(
         address _priceCalculator,
         uint32 _maxTotalRateLimit,
         uint32 _minMembershipRateLimit,
         uint32 _maxMembershipRateLimit,
-        uint32 _expirationTerm,
+        uint32 _activeStateDuration,
         uint32 _gracePeriod
     )
         public
@@ -84,7 +84,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
             _maxTotalRateLimit,
             _minMembershipRateLimit,
             _maxMembershipRateLimit,
-            _expirationTerm,
+            _activeStateDuration,
             _gracePeriod
         );
 
@@ -285,10 +285,10 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     }
 
     /// @notice Set the expiration term for new memberships (expiration dates of existing memberships don't change)
-    /// @param _expirationTerm  new expiration term
-    function setExpirationTerm(uint32 _expirationTerm) external onlyOwner {
-        require(_expirationTerm > 0);
-        expirationTerm = _expirationTerm;
+    /// @param _activeStateDuration  new expiration term
+    function setactiveStateDuration(uint32 _activeStateDuration) external onlyOwner {
+        require(_activeStateDuration > 0);
+        activeStateDuration = _activeStateDuration;
     }
 
     /// @notice Set the grace period for new memberships (grace periods of existing memberships don't change)

--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -164,7 +164,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
             uint256 idCommitmentToErase = idCommitmentsToErase[i];
             MembershipInfo memory membershipToErase = memberships[idCommitmentToErase];
             if (membershipToErase.rateLimit == 0) revert InvalidIdCommitment(idCommitmentToErase);
-            _eraseMembership(_msgSender(), idCommitmentToErase, membershipToErase);
+            _eraseMembershipAndSaveSlotToReuse(_msgSender(), idCommitmentToErase, membershipToErase);
             LazyIMT.update(merkleTree, 0, membershipToErase.index);
         }
 
@@ -251,7 +251,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
             uint256 idCommitmentToErase = idCommitments[i];
             MembershipInfo memory membershipToErase = memberships[idCommitmentToErase];
             if (membershipToErase.rateLimit == 0) revert InvalidIdCommitment(idCommitmentToErase);
-            _eraseMembership(_msgSender(), idCommitmentToErase, membershipToErase);
+            _eraseMembershipAndSaveSlotToReuse(_msgSender(), idCommitmentToErase, membershipToErase);
             LazyIMT.update(merkleTree, 0, membershipToErase.index);
         }
     }

--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -11,17 +11,17 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { MembershipUpgradeable } from "./Membership.sol";
 import { IPriceCalculator } from "./IPriceCalculator.sol";
 
-/// The tree is full
-error FullTree();
+/// The membership set is full
+error FullMembershipSet();
 
-/// Member is already registered
+/// A membership with this idCommitment is already registered
 error DuplicateIdCommitment();
 
 /// Invalid idCommitment
 error InvalidIdCommitment(uint256 idCommitment);
 
-/// Invalid userMessageLimit
-error InvalidUserMessageLimit(uint32 messageLimit);
+/// Invalid membership rate limit // FIXME: this is not used - remove?
+error InvalidMembershipRateLimit(uint32 rateLimit);
 
 /// Invalid pagination query
 error InvalidPaginationQuery(uint256 startIndex, uint256 endIndex);
@@ -31,27 +31,27 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     uint256 public constant Q =
         21_888_242_871_839_275_222_246_405_745_257_275_088_548_364_400_416_034_343_698_204_186_575_808_495_617;
 
-    /// @notice The depth of the merkle tree
-    uint8 public constant DEPTH = 20;
+    /// @notice The depth of the Merkle tree that stores rate commitments of memberships
+    uint8 public constant MERKLE_TREE_DEPTH = 20;
 
-    /// @notice The size of the merkle tree, i.e 2^depth
-    uint32 public SET_SIZE;
+    /// @notice The maximum membership set size is the size of the Merkle tree (2 ^ depth)
+    uint32 public MAX_MEMBERSHIP_SET_SIZE;
 
-    /// @notice the deployed block number
+    /// @notice The block number at which this contract was deployed
     uint32 public deployedBlockNumber;
 
-    /// @notice the stored imt data
-    LazyIMTData public imtData;
+    /// @notice The Merkle tree that stores rate commitments of memberships
+    LazyIMTData public merkleTree;
 
-    /// Emitted when a new member is added to the set
-    /// @param rateCommitment the rateCommitment of the member
-    /// @param index The index of the member in the set
-    event MemberRegistered(uint256 rateCommitment, uint32 index);
+    /// Emitted when a new membership is added to the membership set
+    /// @param rateCommitment The rateCommitment of the membership
+    /// @param index The index of the membership in the membership set
+    event MembershipRegistered(uint256 rateCommitment, uint32 index);
 
     /// @notice the modifier to check if the idCommitment is valid
-    /// @param idCommitment The idCommitment of the member
+    /// @param idCommitment The idCommitment of the membership
     modifier onlyValidIdCommitment(uint256 idCommitment) {
-        if (!isValidCommitment(idCommitment)) revert InvalidIdCommitment(idCommitment);
+        if (!isValidIdCommitment(idCommitment)) revert InvalidIdCommitment(idCommitment);
         _;
     }
 
@@ -61,14 +61,14 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
 
     /// @dev contract initializer
     /// @param _priceCalculator Address of an instance of IPriceCalculator
-    /// @param _maxTotalRateLimitPerEpoch Maximum total rate limit of all memberships in the tree
+    /// @param _maxTotalRateLimit Maximum total rate limit of all memberships FIXME: clarify: excl expired?
     /// @param _minRateLimitPerMembership Minimum rate limit of one membership
     /// @param _maxRateLimitPerMembership Maximum rate limit of one membership
     /// @param _expirationTerm Membership expiration term
     /// @param _gracePeriod Membership grace period
     function initialize(
         address _priceCalculator,
-        uint32 _maxTotalRateLimitPerEpoch,
+        uint32 _maxTotalRateLimit,
         uint32 _minRateLimitPerMembership,
         uint32 _maxRateLimitPerMembership,
         uint32 _expirationTerm,
@@ -81,176 +81,176 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
         __UUPSUpgradeable_init();
         __MembershipUpgradeable_init(
             _priceCalculator,
-            _maxTotalRateLimitPerEpoch,
+            _maxTotalRateLimit,
             _minRateLimitPerMembership,
             _maxRateLimitPerMembership,
             _expirationTerm,
             _gracePeriod
         );
 
-        SET_SIZE = uint32(1 << DEPTH);
+        MAX_MEMBERSHIP_SET_SIZE = uint32(1 << MERKLE_TREE_DEPTH);
         deployedBlockNumber = uint32(block.number);
-        LazyIMT.init(imtData, DEPTH);
-        nextCommitmentIndex = 0;
+        LazyIMT.init(merkleTree, MERKLE_TREE_DEPTH);
+        nextFreeIndex = 0;
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner { } // solhint-disable-line
 
-    /// @notice Checks if a commitment is valid
-    /// @param idCommitment The idCommitment of the member
-    /// @return true if the commitment is valid, false otherwise
-    function isValidCommitment(uint256 idCommitment) public pure returns (bool) {
+    /// @notice Checks if an idCommitment is valid
+    /// @param idCommitment The idCommitment of the membership
+    /// @return true if the idCommitment is valid, false otherwise
+    function isValidIdCommitment(uint256 idCommitment) public pure returns (bool) {
         return idCommitment != 0 && idCommitment < Q;
     }
 
-    /// @notice Returns the rateCommitment of a member
-    /// @param index The index of the member
-    /// @return The rateCommitment of the member
-    function indexToCommitment(uint32 index) internal view returns (uint256) {
-        return imtData.elements[LazyIMT.indexForElement(0, index)];
+    /// @notice Returns the rateCommitment of a membership at a given index
+    /// @param index The index of the membership in the membership set
+    /// @return The rateCommitment of the membership
+    function getRateCommmitment(uint32 index) internal view returns (uint256) {
+        return merkleTree.elements[LazyIMT.indexForElement(0, index)];
     }
 
-    /// @notice Returns the metadata of a member
-    /// @param idCommitment The idCommitment of the member
-    /// @return The metadata of the member (userMessageLimit, index, rateCommitment)
-    function idCommitmentToMetadata(uint256 idCommitment) public view returns (uint32, uint32, uint256) {
-        MembershipInfo memory mdetails = members[idCommitment];
-        // we cannot call indexToCommitment for 0 index if the member doesn't exist
-        if (mdetails.userMessageLimit == 0) {
+    /// @notice Returns the membership info (rate limit, index, rateCommitment) by its idCommitment
+    /// @param idCommitment The idCommitment of the membership
+    /// @return The membership info (rateLimit, index, rateCommitment)
+    function getMembershipInfo(uint256 idCommitment) public view returns (uint32, uint32, uint256) {
+        MembershipInfo memory membership = memberships[idCommitment];
+        // we cannot call getRateCommmitment for 0 index if the membership doesn't exist
+        if (membership.rateLimit == 0) {
             return (0, 0, 0);
         }
-        return (mdetails.userMessageLimit, mdetails.index, indexToCommitment(mdetails.index));
+        return (membership.rateLimit, membership.index, getRateCommmitment(membership.index));
     }
 
-    /// @notice Checks if a member exists
-    /// @param idCommitment The idCommitment of the member
-    /// @return true if the member exists, false otherwise
-    function memberExists(uint256 idCommitment) public view returns (bool) {
-        (,, uint256 rateCommitment) = idCommitmentToMetadata(idCommitment);
+    /// @notice Checks if a membership exists
+    /// @param idCommitment The idCommitment of the membership
+    /// @return true if the membership exists, false otherwise
+    function membershipExists(uint256 idCommitment) public view returns (bool) {
+        (,, uint256 rateCommitment) = getMembershipInfo(idCommitment);
         return rateCommitment != 0;
     }
 
-    /// @notice Allows a user to register as a member
-    /// @param idCommitment The idCommitment of the member
-    /// @param userMessageLimit The message limit of the member
-    function register(uint256 idCommitment, uint32 userMessageLimit) external onlyValidIdCommitment(idCommitment) {
-        if (memberExists(idCommitment)) revert DuplicateIdCommitment();
+    /// @notice Register a membership
+    /// @param idCommitment The idCommitment of the new membership
+    /// @param rateLimit The rate limit of the new membership
+    function register(uint256 idCommitment, uint32 rateLimit) external onlyValidIdCommitment(idCommitment) {
+        if (membershipExists(idCommitment)) revert DuplicateIdCommitment();
 
         uint32 index;
-        bool reusedIndex;
-        (index, reusedIndex) = _acquireMembership(_msgSender(), idCommitment, userMessageLimit);
+        bool reuseIndex;
+        (index, reuseIndex) = _acquireMembership(_msgSender(), idCommitment, rateLimit);
 
-        _register(idCommitment, userMessageLimit, index, reusedIndex);
+        _register(idCommitment, rateLimit, index, reuseIndex);
     }
 
-    /// @notice Allows a user to register as a member
-    /// @param idCommitment The idCommitment of the member
-    /// @param userMessageLimit The message limit of the member
-    /// @param membershipsToErase List of expired idCommitments to erase
+    /// @notice Register a membership
+    /// @param idCommitment The idCommitment of the new membership
+    /// @param rateLimit The rate limit of the new membership
+    /// @param idCommitmentsToErase List of idCommitments of expired memberships to erase
     function register(
         uint256 idCommitment,
-        uint32 userMessageLimit,
-        uint256[] calldata membershipsToErase
+        uint32 rateLimit,
+        uint256[] calldata idCommitmentsToErase
     )
         external
         onlyValidIdCommitment(idCommitment)
     {
-        if (memberExists(idCommitment)) revert DuplicateIdCommitment();
+        if (membershipExists(idCommitment)) revert DuplicateIdCommitment();
 
-        for (uint256 i = 0; i < membershipsToErase.length; i++) {
-            uint256 idCommitmentToErase = membershipsToErase[i];
-            MembershipInfo memory mdetails = members[idCommitmentToErase];
-            if (mdetails.userMessageLimit == 0) revert InvalidIdCommitment(idCommitmentToErase);
-            _eraseMembership(_msgSender(), idCommitmentToErase, mdetails);
-            LazyIMT.update(imtData, 0, mdetails.index);
+        for (uint256 i = 0; i < idCommitmentsToErase.length; i++) {
+            uint256 idCommitmentToErase = idCommitmentsToErase[i];
+            MembershipInfo memory membershipToErase = memberships[idCommitmentToErase];
+            if (membershipToErase.rateLimit == 0) revert InvalidIdCommitment(idCommitmentToErase);
+            _eraseMembership(_msgSender(), idCommitmentToErase, membershipToErase);
+            LazyIMT.update(merkleTree, 0, membershipToErase.index);
         }
 
         uint32 index;
-        bool reusedIndex;
-        (index, reusedIndex) = _acquireMembership(_msgSender(), idCommitment, userMessageLimit);
+        bool reuseIndex;
+        (index, reuseIndex) = _acquireMembership(_msgSender(), idCommitment, rateLimit);
 
-        _register(idCommitment, userMessageLimit, index, reusedIndex);
+        _register(idCommitment, rateLimit, index, reuseIndex);
     }
 
-    /// @dev Registers a member
-    /// @param idCommitment The idCommitment of the member
-    /// @param userMessageLimit The message limit of the member
-    /// @param index Indicates the index in the merkle tree
-    /// @param reusedIndex indicates whether we're inserting a new element in the merkle tree or updating a existing
-    /// leaf
-    function _register(uint256 idCommitment, uint32 userMessageLimit, uint32 index, bool reusedIndex) internal {
-        if (nextCommitmentIndex >= SET_SIZE) revert FullTree();
+    /// @dev Registers a membership
+    /// @param idCommitment The idCommitment of the membership
+    /// @param rateLimit The rate limit of the membership
+    /// @param index The index of the membership in the membership set
+    /// @param reuseIndex Indicates whether we're inserting a new element in the Merkle tree or updating a existing
+    /// element
+    function _register(uint256 idCommitment, uint32 rateLimit, uint32 index, bool reuseIndex) internal {
+        if (nextFreeIndex >= MAX_MEMBERSHIP_SET_SIZE) revert FullMembershipSet();
 
-        uint256 rateCommitment = PoseidonT3.hash([idCommitment, userMessageLimit]);
-        if (reusedIndex) {
-            LazyIMT.update(imtData, rateCommitment, index);
+        uint256 rateCommitment = PoseidonT3.hash([idCommitment, rateLimit]);
+        if (reuseIndex) {
+            LazyIMT.update(merkleTree, rateCommitment, index);
         } else {
-            LazyIMT.insert(imtData, rateCommitment);
-            nextCommitmentIndex += 1;
+            LazyIMT.insert(merkleTree, rateCommitment);
+            nextFreeIndex += 1;
         }
 
-        emit MemberRegistered(rateCommitment, index);
+        emit MembershipRegistered(rateCommitment, index);
     }
 
-    /// @notice Returns the commitments of a range of members
-    /// @param startIndex The start index of the range
-    /// @param endIndex The end index of the range
-    /// @return The commitments of the members
-    function getCommitments(uint32 startIndex, uint32 endIndex) public view returns (uint256[] memory) {
+    /// @notice Returns the rateCommitments of memberships within an index range
+    /// @param startIndex The start index of the range (inclusive)
+    /// @param endIndex The end index of the range (inclusive)
+    /// @return The rateCommitments of the memberships
+    function getRateCommitmentsInRange(uint32 startIndex, uint32 endIndex) public view returns (uint256[] memory) {
         if (startIndex > endIndex) revert InvalidPaginationQuery(startIndex, endIndex);
-        if (endIndex > nextCommitmentIndex) revert InvalidPaginationQuery(startIndex, endIndex);
+        if (endIndex > nextFreeIndex) revert InvalidPaginationQuery(startIndex, endIndex); //FIXME: should it be >=?
 
-        uint256[] memory commitments = new uint256[](endIndex - startIndex + 1);
+        uint256[] memory rateCommitments = new uint256[](endIndex - startIndex + 1);
         for (uint32 i = startIndex; i <= endIndex; i++) {
-            commitments[i - startIndex] = indexToCommitment(i);
+            rateCommitments[i - startIndex] = getRateCommmitment(i);
         }
-        return commitments;
+        return rateCommitments;
     }
 
-    /// @notice Returns the root of the IMT
-    /// @return The root of the IMT
+    /// @notice Returns the root of the Merkle tree that stores rate commitments of memberships
+    /// @return The root of the Merkle tree that stores rate commitments of memberships
     function root() external view returns (uint256) {
-        return LazyIMT.root(imtData, DEPTH);
+        return LazyIMT.root(merkleTree, MERKLE_TREE_DEPTH);
     }
 
-    /// @notice Returns the merkle proof elements of a given membership
-    /// @param index The index of the member
-    /// @return The merkle proof elements of the member
-    function merkleProofElements(uint40 index) public view returns (uint256[DEPTH] memory) {
-        uint256[DEPTH] memory castedProof;
-        uint256[] memory proof = LazyIMT.merkleProofElements(imtData, index, DEPTH);
-        for (uint8 i = 0; i < DEPTH; i++) {
-            castedProof[i] = proof[i];
+    /// @notice Returns the Merkle proof that a given membership is in the membership set
+    /// @param index The index of the membership
+    /// @return The Merkle proof (an array of MERKLE_TREE_DEPTH elements)
+    function getMerkleProof(uint40 index) public view returns (uint256[MERKLE_TREE_DEPTH] memory) {
+        uint256[] memory dynamicSizeProof = LazyIMT.merkleProofElements(merkleTree, index, MERKLE_TREE_DEPTH);
+        uint256[MERKLE_TREE_DEPTH] memory fixedSizeProof;
+        for (uint8 i = 0; i < MERKLE_TREE_DEPTH; i++) {
+            fixedSizeProof[i] = dynamicSizeProof[i];
         }
-        return castedProof;
+        return fixedSizeProof;
     }
 
-    /// @notice Extend a membership expiration date. Memberships must be on grace period
-    /// @param idCommitments list of idcommitments
-    function extend(uint256[] calldata idCommitments) external {
+    /// @notice Extend a grace-period membership
+    /// @param idCommitments list of idCommitments of memberships to extend
+    function extendMemberships(uint256[] calldata idCommitments) external {
         for (uint256 i = 0; i < idCommitments.length; i++) {
-            uint256 idCommitment = idCommitments[i];
-            _extendMembership(_msgSender(), idCommitment);
+            uint256 idCommitmentToExtend = idCommitments[i];
+            _extendMembership(_msgSender(), idCommitmentToExtend);
         }
     }
 
-    /// @notice Remove expired memberships or owned memberships in grace period.
-    /// The user can determine offchain which expired memberships slots
-    /// are available, and proceed to free them.
-    /// This is also used to erase memberships in grace period if they're
-    /// held by the sender. The sender can then withdraw the tokens.
-    /// @param idCommitments list of idcommitments of the memberships
+    /// @notice Erase expired memberships or owned grace-period memberships
+    /// The user can select expired memberships offchain,
+    /// and proceed to erase them.
+    /// This function is also used to erase the user's own grace-period memberships.
+    /// The user (i.e. the transaction sender) can then withdraw the deposited tokens.
+    /// @param idCommitments list of idCommitments of the memberships to erase
     function eraseMemberships(uint256[] calldata idCommitments) external {
-        for (uint256 i = 0; i < idCommitments.length; i++) {
-            uint256 idCommitment = idCommitments[i];
-            MembershipInfo memory mdetails = members[idCommitment];
-            if (mdetails.userMessageLimit == 0) revert InvalidIdCommitment(idCommitment);
-            _eraseMembership(_msgSender(), idCommitment, mdetails);
-            LazyIMT.update(imtData, 0, mdetails.index);
+        for (uint256 i = 0; i < idCommitments.length; i++) {  // FIXME: not DRY: see register()
+            uint256 idCommitmentToErase = idCommitments[i];
+            MembershipInfo memory membershipToErase = memberships[idCommitmentToErase];
+            if (membershipToErase.rateLimit == 0) revert InvalidIdCommitment(idCommitmentToErase);
+            _eraseMembership(_msgSender(), idCommitmentToErase, membershipToErase);
+            LazyIMT.update(merkleTree, 0, membershipToErase.index);
         }
     }
 
-    /// @notice Withdraw any available balance in tokens after a membership is erased.
+    /// @notice Withdraw any available deposit balance in tokens after a membership is erased.
     /// @param token The address of the token to withdraw. Use 0x000...000 to withdraw ETH
     function withdraw(address token) external {
         _withdraw(_msgSender(), token);
@@ -262,37 +262,37 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
         priceCalculator = IPriceCalculator(_priceCalculator);
     }
 
-    /// @notice Set the maximum total rate limit of all memberships in the tree
-    /// @param _maxTotalRateLimitPerEpoch new value
-    function setMaxTotalRateLimitPerEpoch(uint32 _maxTotalRateLimitPerEpoch) external onlyOwner {
-        require(_maxTotalRateLimitPerEpoch >= maxRateLimitPerMembership);
-        maxTotalRateLimitPerEpoch = _maxTotalRateLimitPerEpoch;
+    /// @notice Set the maximum total rate limit of all (FIXME: excl expired?) memberships in the membership set
+    /// @param _maxTotalRateLimit new maximum total rate limit (messages per epoch)
+    function setmaxTotalRateLimit(uint32 _maxTotalRateLimit) external onlyOwner {
+        require(_maxTotalRateLimit >= maxRateLimitPerMembership);
+        maxTotalRateLimit = _maxTotalRateLimit;
     }
 
     /// @notice Set the maximum rate limit of one membership
-    /// @param _maxRateLimitPerMembership  new value
+    /// @param _maxRateLimitPerMembership  new maximum rate limit per membership (messages per epoch)
     function setMaxRateLimitPerMembership(uint32 _maxRateLimitPerMembership) external onlyOwner {
         require(_maxRateLimitPerMembership >= minRateLimitPerMembership);
         maxRateLimitPerMembership = _maxRateLimitPerMembership;
     }
 
     /// @notice Set the minimum rate limit of one membership
-    /// @param _minRateLimitPerMembership  new value
+    /// @param _minRateLimitPerMembership  new minimum rate limit per membership (messages per epoch)
     function setMinRateLimitPerMembership(uint32 _minRateLimitPerMembership) external onlyOwner {
-        require(_minRateLimitPerMembership > 0);
+        require(_minRateLimitPerMembership > 0);  // FIXME: we must also check here that min rate <= max rate
         minRateLimitPerMembership = _minRateLimitPerMembership;
     }
 
-    /// @notice Set the membership expiration term
-    /// @param _expirationTerm  new value
+    /// @notice Set the expiration term for new memberships (expiration dates of existing memberships don't change)
+    /// @param _expirationTerm  new expiration term
     function setExpirationTerm(uint32 _expirationTerm) external onlyOwner {
         require(_expirationTerm > 0);
         expirationTerm = _expirationTerm;
     }
 
-    /// @notice Set the membership grace period
-    /// @param _gracePeriod  new value
-    function setGracePeriod(uint32 _gracePeriod) external onlyOwner {
+    /// @notice Set the grace period for new memberships (grace periods of existing memberships don't change)
+    /// @param _gracePeriod  new grace period term
+    function setGracePeriod(uint32 _gracePeriod) external onlyOwner { // FIXME: shall we check that _gracePeriod > 0?
         gracePeriod = _gracePeriod;
     }
 }

--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -252,7 +252,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     }
 
     /// @notice Withdraw any available deposit balance in tokens after a membership is erased.
-    /// @param token The address of the token to withdraw. Use 0x000...000 to withdraw ETH
+    /// @param token The address of the token to withdraw
     function withdraw(address token) external {
         _withdraw(_msgSender(), token);
     }

--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -134,6 +134,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     /// @param idCommitment The idCommitment of the new membership
     /// @param rateLimit The rate limit of the new membership
     function register(uint256 idCommitment, uint32 rateLimit) external onlyValidIdCommitment(idCommitment) {
+        // FIXME: turn into modifier?
         if (membershipExists(idCommitment)) revert DuplicateIdCommitment();
 
         uint32 index;
@@ -155,8 +156,10 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
         external
         onlyValidIdCommitment(idCommitment)
     {
+        // FIXME: turn into modifier?
         if (membershipExists(idCommitment)) revert DuplicateIdCommitment();
 
+        // FIXME: extract in a separate function?
         for (uint256 i = 0; i < idCommitmentsToErase.length; i++) {
             uint256 idCommitmentToErase = idCommitmentsToErase[i];
             MembershipInfo memory membershipToErase = memberships[idCommitmentToErase];
@@ -165,6 +168,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
             LazyIMT.update(merkleTree, 0, membershipToErase.index);
         }
 
+        // FIXME: code repeats cf. register()
         uint32 index;
         bool indexReused;
         (index, indexReused) = _acquireMembership(_msgSender(), idCommitment, rateLimit);
@@ -179,6 +183,7 @@ contract WakuRlnV2 is Initializable, Ownable2StepUpgradeable, UUPSUpgradeable, M
     /// @param indexReused Indicates whether we're inserting a new element in the Merkle tree or updating a existing
     /// element
     function _register(uint256 idCommitment, uint32 rateLimit, uint32 index, bool indexReused) internal {
+        // FIXME: check this earlier, e.g. as a modifier to register() functions?
         if (nextFreeIndex >= MAX_MEMBERSHIP_SET_SIZE) revert FullMembershipSet();
 
         uint256 rateCommitment = PoseidonT3.hash([idCommitment, rateLimit]);

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -339,11 +339,11 @@ contract WakuRlnV2Test is Test {
         // Attempt to expire 3 commitments that can be erased
         commitmentsToErase[2] = 4;
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpiredAndErased(1, 0, 0);
+        emit MembershipUpgradeable.MembershipExpired(1, 0, 0);
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpiredAndErased(2, 0, 0);
+        emit MembershipUpgradeable.MembershipExpired(2, 0, 0);
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpiredAndErased(4, 0, 0);
+        emit MembershipUpgradeable.MembershipExpired(4, 0, 0);
         w.register(6, 60, commitmentsToErase);
 
         // Ensure that the chosen memberships were erased and others unaffected
@@ -433,28 +433,28 @@ contract WakuRlnV2Test is Test {
 
         // Verify that expired indices match what we expect
         for (uint32 i = 0; i < idCommitmentsLength; i++) {
-            assertEq(i, w.reusableMembershipsIndices(i));
+            assertEq(i, w.reusableIndicesOfErasableMemberships(i));
         }
 
         uint32 currnextCommitmentIndex = w.nextFreeIndex();
         for (uint256 i = 1; i <= idCommitmentsLength; i++) {
             uint256 idCommitment = i + 10;
             uint256 expectedindexReusedPos = idCommitmentsLength - i;
-            uint32 expectedIndex = w.reusableMembershipsIndices(expectedindexReusedPos);
+            uint32 expectedIndex = w.reusableIndicesOfErasableMemberships(expectedindexReusedPos);
             token.approve(address(w), price);
             w.register(idCommitment, 20);
             (,,,, index,,) = w.memberships(idCommitment);
             assertEq(expectedIndex, index);
             // Should have been removed from the list
             vm.expectRevert();
-            w.reusableMembershipsIndices(expectedindexReusedPos);
+            w.reusableIndicesOfErasableMemberships(expectedindexReusedPos);
             // Should not have been affected
             assertEq(currnextCommitmentIndex, w.nextFreeIndex());
         }
 
         // No indexes should be available for reuse
         vm.expectRevert();
-        w.reusableMembershipsIndices(0);
+        w.reusableIndicesOfErasableMemberships(0);
 
         // Should use a new index since we got rid of all available indexes
         token.approve(address(w), price);
@@ -498,9 +498,9 @@ contract WakuRlnV2Test is Test {
         commitmentsToErase[1] = idCommitment + 2;
 
         vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-        emit MembershipUpgradeable.MembershipExpiredAndErased(commitmentsToErase[0], 0, 0);
+        emit MembershipUpgradeable.MembershipExpired(commitmentsToErase[0], 0, 0);
         vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-        emit MembershipUpgradeable.MembershipExpiredAndErased(commitmentsToErase[0], 0, 0);
+        emit MembershipUpgradeable.MembershipExpired(commitmentsToErase[0], 0, 0);
         w.eraseMemberships(commitmentsToErase);
 
         address holder;
@@ -546,7 +546,7 @@ contract WakuRlnV2Test is Test {
         for (uint256 i = 0; i < idCommitmentsLength; i++) {
             commitmentsToErase[i] = i + 1;
             vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-            emit MembershipUpgradeable.MembershipExpiredAndErased(i + 1, 0, 0);
+            emit MembershipUpgradeable.MembershipExpired(i + 1, 0, 0);
         }
 
         w.eraseMemberships(commitmentsToErase);

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -339,11 +339,11 @@ contract WakuRlnV2Test is Test {
         // Attempt to expire 3 commitments that can be erased
         commitmentsToErase[2] = 4;
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpired(1, 0, 0);
+        emit MembershipUpgradeable.MembershipExpiredAndErased(1, 0, 0);
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpired(2, 0, 0);
+        emit MembershipUpgradeable.MembershipExpiredAndErased(2, 0, 0);
         vm.expectEmit(true, false, false, false);
-        emit MembershipUpgradeable.MembershipExpired(4, 0, 0);
+        emit MembershipUpgradeable.MembershipExpiredAndErased(4, 0, 0);
         w.register(6, 60, commitmentsToErase);
 
         // Ensure that the chosen memberships were erased and others unaffected
@@ -433,28 +433,28 @@ contract WakuRlnV2Test is Test {
 
         // Verify that expired indices match what we expect
         for (uint32 i = 0; i < idCommitmentsLength; i++) {
-            assertEq(i, w.availableExpiredMembershipsIndices(i));
+            assertEq(i, w.reusableMembershipsIndices(i));
         }
 
         uint32 currnextCommitmentIndex = w.nextFreeIndex();
         for (uint256 i = 1; i <= idCommitmentsLength; i++) {
             uint256 idCommitment = i + 10;
             uint256 expectedindexReusedPos = idCommitmentsLength - i;
-            uint32 expectedIndex = w.availableExpiredMembershipsIndices(expectedindexReusedPos);
+            uint32 expectedIndex = w.reusableMembershipsIndices(expectedindexReusedPos);
             token.approve(address(w), price);
             w.register(idCommitment, 20);
             (,,,, index,,) = w.memberships(idCommitment);
             assertEq(expectedIndex, index);
             // Should have been removed from the list
             vm.expectRevert();
-            w.availableExpiredMembershipsIndices(expectedindexReusedPos);
+            w.reusableMembershipsIndices(expectedindexReusedPos);
             // Should not have been affected
             assertEq(currnextCommitmentIndex, w.nextFreeIndex());
         }
 
         // No indexes should be available for reuse
         vm.expectRevert();
-        w.availableExpiredMembershipsIndices(0);
+        w.reusableMembershipsIndices(0);
 
         // Should use a new index since we got rid of all available indexes
         token.approve(address(w), price);
@@ -498,9 +498,9 @@ contract WakuRlnV2Test is Test {
         commitmentsToErase[1] = idCommitment + 2;
 
         vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-        emit MembershipUpgradeable.MembershipExpired(commitmentsToErase[0], 0, 0);
+        emit MembershipUpgradeable.MembershipExpiredAndErased(commitmentsToErase[0], 0, 0);
         vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-        emit MembershipUpgradeable.MembershipExpired(commitmentsToErase[0], 0, 0);
+        emit MembershipUpgradeable.MembershipExpiredAndErased(commitmentsToErase[0], 0, 0);
         w.eraseMemberships(commitmentsToErase);
 
         address holder;
@@ -546,7 +546,7 @@ contract WakuRlnV2Test is Test {
         for (uint256 i = 0; i < idCommitmentsLength; i++) {
             commitmentsToErase[i] = i + 1;
             vm.expectEmit(true, false, false, false); // only check the first parameter of the event (the idCommitment)
-            emit MembershipUpgradeable.MembershipExpired(i + 1, 0, 0);
+            emit MembershipUpgradeable.MembershipExpiredAndErased(i + 1, 0, 0);
         }
 
         w.eraseMemberships(commitmentsToErase);

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -59,7 +59,8 @@ contract WakuRlnV2Test is Test {
             w.root(),
             13_801_897_483_540_040_307_162_267_952_866_411_686_127_372_014_953_358_983_481_592_640_000_001_877_295
         );
-        (uint32 fetchedMembershipRateLimit2, uint32 index2, uint256 rateCommitment2) = w.getMembershipInfo(idCommitment);
+        (uint32 fetchedMembershipRateLimit2, uint32 index2, uint256 rateCommitment2) =
+            w.getMembershipInfo(idCommitment);
         assertEq(fetchedMembershipRateLimit2, membershipRateLimit);
         assertEq(index2, 0);
         assertEq(rateCommitment2, rateCommitment);
@@ -433,28 +434,28 @@ contract WakuRlnV2Test is Test {
 
         // Verify that expired indices match what we expect
         for (uint32 i = 0; i < idCommitmentsLength; i++) {
-            assertEq(i, w.reusableIndicesOfErasableMemberships(i));
+            assertEq(i, w.reusableIndicesOfErasedMemberships(i));
         }
 
         uint32 currnextCommitmentIndex = w.nextFreeIndex();
         for (uint256 i = 1; i <= idCommitmentsLength; i++) {
             uint256 idCommitment = i + 10;
             uint256 expectedindexReusedPos = idCommitmentsLength - i;
-            uint32 expectedIndex = w.reusableIndicesOfErasableMemberships(expectedindexReusedPos);
+            uint32 expectedIndex = w.reusableIndicesOfErasedMemberships(expectedindexReusedPos);
             token.approve(address(w), price);
             w.register(idCommitment, 20);
             (,,,, index,,) = w.memberships(idCommitment);
             assertEq(expectedIndex, index);
             // Should have been removed from the list
             vm.expectRevert();
-            w.reusableIndicesOfErasableMemberships(expectedindexReusedPos);
+            w.reusableIndicesOfErasedMemberships(expectedindexReusedPos);
             // Should not have been affected
             assertEq(currnextCommitmentIndex, w.nextFreeIndex());
         }
 
         // No indexes should be available for reuse
         vm.expectRevert();
-        w.reusableIndicesOfErasableMemberships(0);
+        w.reusableIndicesOfErasedMemberships(0);
 
         // Should use a new index since we got rid of all available indexes
         token.approve(address(w), price);

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -199,12 +199,12 @@ contract WakuRlnV2Test is Test {
         w.register(idCommitment, membershipRateLimit);
         (, uint256 gracePeriodStartTimestamp,,,,,) = w.memberships(idCommitment);
 
-        assertFalse(w.isInGracePeriodNow(idCommitment));
+        assertFalse(w.isInGracePeriod(idCommitment));
         assertFalse(w.isExpired(idCommitment));
 
         vm.warp(gracePeriodStartTimestamp);
 
-        assertTrue(w.isInGracePeriodNow(idCommitment));
+        assertTrue(w.isInGracePeriod(idCommitment));
         assertFalse(w.isExpired(idCommitment));
 
         uint256[] memory commitmentsToExtend = new uint256[](1);
@@ -224,7 +224,7 @@ contract WakuRlnV2Test is Test {
         (, uint256 newgracePeriodStartTimestamp,,,,,) = w.memberships(idCommitment);
 
         assertEq(block.timestamp + uint256(w.activeStateDuration()), newgracePeriodStartTimestamp);
-        assertFalse(w.isInGracePeriodNow(idCommitment));
+        assertFalse(w.isInGracePeriod(idCommitment));
         assertFalse(w.isExpired(idCommitment));
 
         // Attempt to extend a non grace period membership
@@ -289,7 +289,7 @@ contract WakuRlnV2Test is Test {
 
         vm.warp(membershipExpirationTimestamp);
 
-        assertFalse(w.isInGracePeriodNow(idCommitment));
+        assertFalse(w.isInGracePeriod(idCommitment));
         assertTrue(w.isExpired(idCommitment));
     }
 
@@ -318,7 +318,7 @@ contract WakuRlnV2Test is Test {
         // Ensure that this is the case
         assertTrue(w.isExpired(4));
         assertFalse(w.isExpired(5));
-        assertFalse(w.isInGracePeriodNow(5));
+        assertFalse(w.isInGracePeriod(5));
 
         (, uint256 priceB) = w.priceCalculator().calculate(60);
         token.approve(address(w), priceB);

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -223,7 +223,7 @@ contract WakuRlnV2Test is Test {
 
         (, uint256 newgracePeriodStartTimestamp,,,,,) = w.memberships(idCommitment);
 
-        assertEq(block.timestamp + uint256(w.expirationTerm()), newgracePeriodStartTimestamp);
+        assertEq(block.timestamp + uint256(w.activeStateDuration()), newgracePeriodStartTimestamp);
         assertFalse(w.isInGracePeriodNow(idCommitment));
         assertFalse(w.isExpired(idCommitment));
 
@@ -362,7 +362,7 @@ contract WakuRlnV2Test is Test {
         assertEq(holder, address(this));
 
         // The balance available for withdrawal should match the amount of the expired membership
-        uint256 availableBalance = w.balancesToWithdraw(address(this), address(token));
+        uint256 availableBalance = w.depositsToWithdraw(address(this), address(token));
         assertEq(availableBalance, priceA * 3);
     }
 
@@ -583,7 +583,7 @@ contract WakuRlnV2Test is Test {
         commitmentsToErase[0] = idCommitment;
         w.eraseMemberships(commitmentsToErase);
 
-        uint256 availableBalance = w.balancesToWithdraw(address(this), address(token));
+        uint256 availableBalance = w.depositsToWithdraw(address(this), address(token));
 
         assertEq(availableBalance, price);
         assertEq(token.balanceOf(address(w)), price);
@@ -594,7 +594,7 @@ contract WakuRlnV2Test is Test {
 
         uint256 balanceAfterWithdraw = token.balanceOf(address(this));
 
-        availableBalance = w.balancesToWithdraw(address(this), address(token));
+        availableBalance = w.depositsToWithdraw(address(this), address(token));
         assertEq(availableBalance, 0);
         assertEq(token.balanceOf(address(w)), 0);
         assertEq(balanceBeforeWithdraw + price, balanceAfterWithdraw);


### PR DESCRIPTION
## Description

### Rationale

This PR aims to introduce consistent usage of terms throughout the code to make sure that:
- variable and function names reflect their essence;
- the same thing is called the same name;
- different things are called different names;
- naming is consistent with the [spec](https://github.com/waku-org/specs/blob/master/standards/core/rln-contract.md).

Making terminology consistent will hopefully make it easier to review substantial changes to the contract both in the context of the currentlu open membership-related PRs (#13, #14) as well as for future modifications.

### Terminology

To remain consistent with the spec and between different pieces of code, the following term usage is suggested. This PR implements (but is not limited to) these guidelines:

| Recommended                    | Not recommended              | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| ------------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Membership                     | Member, User                 | By using "animate" notions like "member" or "user", we open up the discussion on who the user is, what distinguishes one users from multiple users, whether one user can register multiple memberships, etc. In the scope of the smart contract, the basic unit we account for is a membership.                                                                                                                                                                                                                                                                                                                                                                                                       |
| Membership set                 | Set, Tree (exceptions apply) | The membership set is the central concept of the RLN protocol. The fact that it is implemented as a Merkle tree, in particular a LazyIMT, is an implementation detail. The suggestion is to use the phrase "membership set" whenever possible, unless dealing with tree-specific functions like getting a Merkle proof. (Although even that can be called "inclusion proof" or something.) When using the word "tree" or its derivatives, clarify in the comments that this tree stores the membership set (or, even more precisely, the rate limits of memberships in the membership set).                                                                                                                                                                                           |
| Rate limit                     | Limit, message limit         | The term "rate limit" corresponds to the spec and also is consistent with the term "rate commitment".                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| Rate commitment, Id commitment | Commitment                   | There are two types of commitments in the code: rate commitments and ID commitments. Using just the word "commitment" can be confusing, as it's not immediately clear which commitment we're talking about. The suggestion is to always specify the type of commitment, including in derivative names of variables and functions, like `getRateCommitment`.                                                                                                                                                                                                                                                                                                                                           |


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added natspec comments?
- [x] Ran `pnpm adorno`?
