### PR TITLE
feat: deploy to Linea

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/foundry-devops"]
+	path = lib/foundry-devops
+	url = https://github.com/Cyfrin/foundry-devops

--- a/README.md
+++ b/README.md
@@ -139,17 +139,30 @@ $ forge test
 
 ## Owner privileges
 
-The contract implementation aims to follow the [specification](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md) that also describes ownership (see [Governance and upgradability](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md#governance-and-upgradability) section).
+The contract implementation aims to follow the
+[specification](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md)
+that also describes ownership (see
+[Governance and upgradability](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md#governance-and-upgradability)
+section).
 
 As of commit afb858, the `Owner` privileges are assigned to the `msg.sender` of the membership registration transaction.
 The `Owner` has the following privileges:
 
-- set the token and price of one message published per epoch ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/LinearPriceCalculator.sol#L25));
-- authorize upgrades to a new implementation contract ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L99));
-- set the price calculator contract address ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L267));
-- set the maximum total rate limit of all memberships in the membership set ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L273));
-- set the minimum ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L287)) and maximum ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L280)) rate limit of one membership;
-- set the duration of the active period ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L295)) and grace period ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L302)) of new memberships (see the [state transition diagram of a membership](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md#membership-lifecycle)).
+- set the token and price of one message published per epoch
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/LinearPriceCalculator.sol#L25));
+- authorize upgrades to a new implementation contract
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L99));
+- set the price calculator contract address
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L267));
+- set the maximum total rate limit of all memberships in the membership set
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L273));
+- set the minimum ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L287)) and maximum
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L280)) rate limit of one
+  membership;
+- set the duration of the active period
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L295)) and grace period
+  ([link](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol#L302)) of new memberships (see the
+  [state transition diagram of a membership](https://github.com/waku-org/specs/blob/81b9fd588bff39894608746774b0903b067b5cdf/standards/core/rln-contract.md#membership-lifecycle)).
 
 The pause functionality for contract functions is not yet implemented.
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,7 @@
   solc = "0.8.24"
   src = "src"
   test = "test"
+  fs_permissions = [{ access = "read", path = "./broadcast" }]
 
 [fuzz]
 max_test_rejects = 128_000

--- a/package.json
+++ b/package.json
@@ -36,7 +36,13 @@
     "adorno": "pnpm prettier:write && forge fmt && forge snapshot && pnpm gas-report",
     "deploy:sepolia": "./envCheck.sh && FOUNDRY_PROFILE=sepolia forge script --chain sepolia script/Deploy.s.sol:Deploy --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
     "deploy:cardona": "export RPC_URL=https://rpc.cardona.zkevm-rpc.com && ./envCheck.sh && FOUNDRY_PROFILE=cardona forge script --chain 2442 script/Deploy.s.sol:Deploy --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
-    "deploy:linea_sepolia": "export RPC_URL=https://rpc.sepolia.linea.build && ./envCheck.sh && FOUNDRY_PROFILE=linea_sepolia forge script --chain 59141  script/Deploy.s.sol:Deploy --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
-    "deploy:localhost": "./envCheck.sh && forge script script/Deploy.s.sol:Deploy --rpc-url $RPC_URL --broadcast -vv --account $ACCOUNT --sender $ETH_FROM"
+    "deploy:localhost:price_calculator": "./envCheck.sh && forge script script/Deploy.s.sol:DeployPriceCalculator --rpc-url $RPC_URL --broadcast -vv --sender $ETH_FROM --account $ACCOUNT",
+    "deploy:localhost:wakurln_impl_v2": "./envCheck.sh && forge script script/Deploy.s.sol:DeployWakuRlnV2 --rpc-url $RPC_URL --broadcast -vv --sender $ETH_FROM --account $ACCOUNT",
+    "deploy:localhost:proxy": "./envCheck.sh && forge script script/Deploy.s.sol:DeployProxy --rpc-url $RPC_URL --broadcast -vv --sender $ETH_FROM --account $ACCOUNT",
+    "deploy:localhost": "npm run deploy:localhost:price_calculator && npm run deploy:localhost:wakurln_impl_v2 && npm run deploy:localhost:proxy",
+    "deploy:linea_sepolia:price_calculator": "export RPC_URL=https://rpc.sepolia.linea.build && ./envCheck.sh && FOUNDRY_PROFILE=linea_sepolia forge script --chain 59141  script/Deploy.s.sol:DeployPriceCalculator --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
+    "deploy:linea_sepolia:wakurln_impl_v2": "export RPC_URL=https://rpc.sepolia.linea.build && ./envCheck.sh && FOUNDRY_PROFILE=linea_sepolia forge script --chain 59141  script/Deploy.s.sol:DeployWakuRlnV2 --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
+    "deploy:linea_sepolia:proxy": "export RPC_URL=https://rpc.sepolia.linea.build && ./envCheck.sh && FOUNDRY_PROFILE=linea_sepolia forge script --chain 59141  script/Deploy.s.sol:DeployProxy --rpc-url $RPC_URL --broadcast --verify -vv --account $ACCOUNT --legacy --sender $ETH_FROM",
+    "deploy:linea_sepolia": "npm run deploy:linea_sepolia:price_calculator && npm run deploy:linea_sepolia:wakurln_impl_v2 && npm run deploy:linea_sepolia:proxy"
   }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -2,25 +2,24 @@
 pragma solidity >=0.8.19 <=0.9.0;
 
 import { WakuRlnV2 } from "../src/WakuRlnV2.sol";
+import { IPriceCalculator } from "../src/IPriceCalculator.sol";
 import { LinearPriceCalculator } from "../src/LinearPriceCalculator.sol";
 import { PoseidonT3 } from "poseidon-solidity/PoseidonT3.sol";
 import { LazyIMT } from "@zk-kit/imt.sol/LazyIMT.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-
+import { DevOpsTools } from "lib/foundry-devops/src/DevOpsTools.sol";
 import { BaseScript } from "./Base.s.sol";
+import "forge-std/console.sol";
 
-contract Deploy is BaseScript {
-    function run() public broadcast returns (WakuRlnV2 w, address impl) {
+contract DeployPriceCalculator is BaseScript {
+    function run() public broadcast returns (address) {
         address _token = _getTokenAddress();
-        return deploy(_token);
+        return address(deploy(_token));
     }
 
-    function deploy(address _token) public returns (WakuRlnV2 w, address impl) {
-        address priceCalcAddr = address(new LinearPriceCalculator(_token, 0.05 ether));
-        impl = address(new WakuRlnV2());
-        bytes memory data = abi.encodeCall(WakuRlnV2.initialize, (priceCalcAddr, 160_000, 20, 600, 180 days, 30 days));
-        address proxy = address(new ERC1967Proxy(impl, data));
-        w = WakuRlnV2(proxy);
+    function deploy(address _token) public returns (IPriceCalculator) {
+        LinearPriceCalculator priceCalculator = new LinearPriceCalculator(_token, 0.05 ether);
+        return IPriceCalculator(priceCalculator);
     }
 
     function _getTokenAddress() internal view returns (address) {
@@ -33,6 +32,65 @@ contract Deploy is BaseScript {
                 revert("no TOKEN_ADDRESS was specified");
             }
         }
+    }
+}
+
+contract DeployWakuRlnV2 is BaseScript {
+    function run() public broadcast returns (address) {
+        return address(deploy());
+    }
+
+    function deploy() public returns (WakuRlnV2) {
+        return new WakuRlnV2();
+    }
+}
+
+contract DeployProxy is BaseScript {
+    uint32 public constant MAX_TOTAL_RATELIMIT_PER_EPOCH = 160_000;
+    uint32 public constant MIN_RATELIMIT_PER_MEMBERSHIP = 20;
+    uint32 public constant MAX_RATELIMIT_PER_MEMBERSHIP = 600;
+    uint32 public constant ACTIVE_DURATION = 180 days;
+    uint32 public constant GRACE_PERIOD_DURATION = 30 days;
+
+    function run() public broadcast returns (address) {
+        address priceCalcAddr;
+        address wakuRlnV2ImplAddr;
+
+        try vm.envAddress("PRICE_CALCULATOR_ADDRESS") returns (address envPriceCalcAddress) {
+            console.log("Loading price calculator address from environment variable");
+            priceCalcAddr = envPriceCalcAddress;
+        } catch {
+            console.log("Loading price calculator address from broadcast directory");
+            priceCalcAddr = DevOpsTools.get_most_recent_deployment("LinearPriceCalculator", block.chainid);
+        }
+
+        try vm.envAddress("WAKURLNV2_ADDRESS") returns (address envWakuRlnV2ImplAddr) {
+            console.log("Loading WakuRlnV2 address from environment variable");
+            wakuRlnV2ImplAddr = envWakuRlnV2ImplAddr;
+        } catch {
+            console.log("Loading WakuRlnV2 address from broadcast directory");
+            wakuRlnV2ImplAddr = DevOpsTools.get_most_recent_deployment("WakuRlnV2", block.chainid);
+        }
+
+        console.log("Using price calculator address: %s", priceCalcAddr);
+        console.log("Using WakuRLNV2 address: %s", wakuRlnV2ImplAddr);
+
+        return address(deploy(priceCalcAddr, wakuRlnV2ImplAddr));
+    }
+
+    function deploy(address _priceCalcAddr, address _wakuRlnV2ImplAddr) public returns (ERC1967Proxy) {
+        bytes memory data = abi.encodeCall(
+            WakuRlnV2.initialize,
+            (
+                _priceCalcAddr,
+                MAX_TOTAL_RATELIMIT_PER_EPOCH,
+                MIN_RATELIMIT_PER_MEMBERSHIP,
+                MAX_RATELIMIT_PER_MEMBERSHIP,
+                ACTIVE_DURATION,
+                GRACE_PERIOD_DURATION
+            )
+        );
+        return new ERC1967Proxy(_wakuRlnV2ImplAddr, data);
     }
 }
 

--- a/src/Membership.sol
+++ b/src/Membership.sol
@@ -150,7 +150,6 @@ abstract contract MembershipUpgradeable is Initializable {
         internal
         onlyInitializing
     {
-        require(0 < _minMembershipRateLimit);
         require(_minMembershipRateLimit <= _maxMembershipRateLimit);
         require(_maxMembershipRateLimit <= _maxTotalRateLimit);
         require(_activeDurationForNewMemberships > 0);


### PR DESCRIPTION
- Splits deployment script in separate deployments per contract (since we might want in the future to deploy different PriceCalculators or WakuRLNV2 contracts).
- Adds https://github.com/Cyfrin/foundry-devops to retrieve the latest address deployed. (Useful when using multiple scripts)
- Adds separate package.json scripts to control the deployment of each individual contract
- Setups the deployment for Linea Sepolia