### PR TITLE
feat: permit

### DIFF
--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -170,14 +170,55 @@ contract WakuRlnV2 is Initializable, OwnableUpgradeable, UUPSUpgradeable, Member
     {
         // erase memberships without overwriting membership set data to zero (save gas)
         _eraseMemberships(idCommitmentsToErase, false);
-        _register(idCommitment, rateLimit);
+
+        (uint32 index, bool indexReused) = _acquireMembership(_msgSender(), idCommitment, rateLimit);
+
+        _upsertInTree(idCommitment, rateLimit, index, indexReused);
+
+        emit MembershipRegistered(idCommitment, rateLimit, index);
+    }
+
+    /// @notice Register a membership while erasing some expired memberships to reuse their rate limit.
+    /// Uses the RC20 Permit extension allowing approvals to be made via signatures, as defined in
+    /// [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612).
+    /// @param owner The address of the token owner who is giving permission and will own the membership.
+    /// @param deadline The timestamp until when the permit is valid.
+    /// @param v The recovery byte of the signature.
+    /// @param r Half of the ECDSA signature pair.
+    /// @param s Half of the ECDSA signature pair.
+    /// @param idCommitment The idCommitment of the new membership
+    /// @param rateLimit The rate limit of the new membership
+    /// @param idCommitmentsToErase The list of idCommitments of expired memberships to erase
+    function registerWithPermit(
+        address owner,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        uint256 idCommitment,
+        uint32 rateLimit,
+        uint256[] calldata idCommitmentsToErase
+    )
+        external
+        onlyValidIdCommitment(idCommitment)
+        noDuplicateMembership(idCommitment)
+        membershipSetNotFull
+    {
+        // erase memberships without overwriting membership set data to zero (save gas)
+        _eraseMemberships(idCommitmentsToErase, false);
+
+        (uint32 index, bool indexReused) =
+            _acquireMembershipWithPermit(owner, deadline, v, r, s, idCommitment, rateLimit);
+
+        _upsertInTree(idCommitment, rateLimit, index, indexReused);
+
+        emit MembershipRegistered(idCommitment, rateLimit, index);
     }
 
     /// @dev Register a membership (internal function)
     /// @param idCommitment The idCommitment of the membership
     /// @param rateLimit The rate limit of the membership
-    function _register(uint256 idCommitment, uint32 rateLimit) internal {
-        (uint32 index, bool indexReused) = _acquireMembership(_msgSender(), idCommitment, rateLimit);
+    function _upsertInTree(uint256 idCommitment, uint32 rateLimit, uint32 index, bool indexReused) internal {
         uint256 rateCommitment = PoseidonT3.hash([idCommitment, rateLimit]);
         if (indexReused) {
             LazyIMT.update(merkleTree, rateCommitment, index);
@@ -185,8 +226,6 @@ contract WakuRlnV2 is Initializable, OwnableUpgradeable, UUPSUpgradeable, Member
             LazyIMT.insert(merkleTree, rateCommitment);
             nextFreeIndex += 1;
         }
-
-        emit MembershipRegistered(idCommitment, rateLimit, index);
     }
 
     /// @notice Returns the root of the Merkle tree that stores rate commitments of memberships

--- a/test/TestToken.sol
+++ b/test/TestToken.sol
@@ -3,9 +3,10 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { BaseScript } from "../script/Base.s.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
-contract TestToken is ERC20 {
-    constructor() ERC20("TestToken", "TTT") { }
+contract TestToken is ERC20, ERC20Permit {
+    constructor() ERC20("TestToken", "TTT") ERC20Permit("TestToken") { }
 
     function mint(address to, uint256 amount) public {
         _mint(to, amount);


### PR DESCRIPTION
## Description

Considering we're using DAI as the chosen token for membership acquisition, it makes sense to use the permit extension defined in https://eips.ethereum.org/EIPS/eip-2612 so instead of having the users require two separate transactions for registering a membership, to be able to instead use a single transaction

I added a test unit which demonstrates how we can use this functionality

cc: @Ivansete-status, @fryorcraken 