### PR TITLE
chore: Add MINTER-ROLE and list to TST

### DIFF
--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -11,23 +11,28 @@ error AccountAlreadyMinter();
 error AccountNotInMinterList();
 
 contract TestStableToken is ERC20, ERC20Permit, Ownable {
-    mapping(address => bool) public minterRole;
+    mapping(address => bool) public isMinter;
+
+    event MinterAdded(address indexed account);
+    event MinterRemoved(address indexed account);
 
     modifier onlyOwnerOrMinter() {
-        if (msg.sender != owner() && !minterRole[msg.sender]) revert AccountNotMinter();
+        if (msg.sender != owner() && !isMinter[msg.sender]) revert AccountNotMinter();
         _;
     }
 
     constructor() ERC20("TestStableToken", "TST") ERC20Permit("TestStableToken") Ownable() { }
 
-    function addMinterRole(address account) external onlyOwner {
-        if (minterRole[account]) revert AccountAlreadyMinter();
-        minterRole[account] = true;
+    function addMinter(address account) external onlyOwner {
+        if (isMinter[account]) revert AccountAlreadyMinter();
+        isMinter[account] = true;
+        emit MinterAdded(account);
     }
 
-    function removeMinterRole(address account) external onlyOwner {
-        if (!minterRole[account]) revert AccountNotInMinterList();
-        minterRole[account] = false;
+    function removeMinter(address account) external onlyOwner {
+        if (!isMinter[account]) revert AccountNotInMinterList();
+        isMinter[account] = false;
+        emit MinterRemoved(account);
     }
 
     function mint(address to, uint256 amount) external onlyOwnerOrMinter {

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -6,10 +6,31 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
+error AccountNotApproved();
+error AccountAlreadyApproved();
+error AccountNotInList();
+
 contract TestStableToken is ERC20, ERC20Permit, Ownable {
+    mapping(address => bool) public approvedAccounts;
+
+    modifier onlyOwnerOrApproved() {
+        if (msg.sender != owner() && !approvedAccounts[msg.sender]) revert AccountNotApproved();
+        _;
+    }
+
     constructor() ERC20("TestStableToken", "TST") ERC20Permit("TestStableToken") Ownable() { }
 
-    function mint(address to, uint256 amount) external onlyOwner {
+    function addApprovedAccount(address account) external onlyOwner {
+        if (approvedAccounts[account]) revert AccountAlreadyApproved();
+        approvedAccounts[account] = true;
+    }
+
+    function removeApprovedAccount(address account) external onlyOwner {
+        if (!approvedAccounts[account]) revert AccountNotInList();
+        approvedAccounts[account] = false;
+    }
+
+    function mint(address to, uint256 amount) external onlyOwnerOrApproved {
         _mint(to, amount);
     }
 }

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -6,31 +6,31 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-error AccountNotApproved();
-error AccountAlreadyApproved();
-error AccountNotInList();
+error AccountNotMinter();
+error AccountAlreadyMinter();
+error AccountNotInMinterList();
 
 contract TestStableToken is ERC20, ERC20Permit, Ownable {
-    mapping(address => bool) public approvedAccounts;
+    mapping(address => bool) public minterRole;
 
-    modifier onlyOwnerOrApproved() {
-        if (msg.sender != owner() && !approvedAccounts[msg.sender]) revert AccountNotApproved();
+    modifier onlyOwnerOrMinter() {
+        if (msg.sender != owner() && !minterRole[msg.sender]) revert AccountNotMinter();
         _;
     }
 
     constructor() ERC20("TestStableToken", "TST") ERC20Permit("TestStableToken") Ownable() { }
 
-    function addApprovedAccount(address account) external onlyOwner {
-        if (approvedAccounts[account]) revert AccountAlreadyApproved();
-        approvedAccounts[account] = true;
+    function addMinterRole(address account) external onlyOwner {
+        if (minterRole[account]) revert AccountAlreadyMinter();
+        minterRole[account] = true;
     }
 
-    function removeApprovedAccount(address account) external onlyOwner {
-        if (!approvedAccounts[account]) revert AccountNotInList();
-        approvedAccounts[account] = false;
+    function removeMinterRole(address account) external onlyOwner {
+        if (!minterRole[account]) revert AccountNotInMinterList();
+        minterRole[account] = false;
     }
 
-    function mint(address to, uint256 amount) external onlyOwnerOrApproved {
+    function mint(address to, uint256 amount) external onlyOwnerOrMinter {
         _mint(to, amount);
     }
 }

--- a/test/TestStableToken.t.sol
+++ b/test/TestStableToken.t.sol
@@ -2,157 +2,156 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { Test } from "forge-std/Test.sol";
-import { TestStableToken, AccountNotApproved, AccountAlreadyApproved, AccountNotInList } from "./TestStableToken.sol";
+import { TestStableToken, AccountNotMinter, AccountAlreadyMinter, AccountNotInMinterList } from "./TestStableToken.sol";
 
 contract TestStableTokenTest is Test {
     TestStableToken internal token;
     address internal owner;
     address internal user1;
     address internal user2;
-    address internal nonApproved;
+    address internal nonMinter;
 
     function setUp() public {
         token = new TestStableToken();
         owner = address(this);
         user1 = vm.addr(1);
         user2 = vm.addr(2);
-        nonApproved = vm.addr(3);
+        nonMinter = vm.addr(3);
     }
 
-    function test__OwnerCanAddApprovedAccount() external {
-        assertFalse(token.approvedAccounts(user1));
-        
-        token.addApprovedAccount(user1);
-        
-        assertTrue(token.approvedAccounts(user1));
+    function test__OwnerCanAddMinterRole() external {
+        assertFalse(token.minterRole(user1));
+
+        token.addMinterRole(user1);
+
+        assertTrue(token.minterRole(user1));
     }
 
-    function test__OwnerCanRemoveApprovedAccount() external {
-        token.addApprovedAccount(user1);
-        assertTrue(token.approvedAccounts(user1));
-        
-        token.removeApprovedAccount(user1);
-        
-        assertFalse(token.approvedAccounts(user1));
+    function test__OwnerCanRemoveMinterRole() external {
+        token.addMinterRole(user1);
+        assertTrue(token.minterRole(user1));
+
+        token.removeMinterRole(user1);
+
+        assertFalse(token.minterRole(user1));
     }
 
-    function test__OwnerCanMintWithoutApproval() external {
+    function test__OwnerCanMintWithoutMinterRole() external {
         uint256 mintAmount = 1000 ether;
-        
+
         token.mint(user1, mintAmount);
-        
+
         assertEq(token.balanceOf(user1), mintAmount);
     }
 
-    function test__NonOwnerCannotAddApprovedAccount() external {
+    function test__NonOwnerCannotAddMinterRole() external {
         vm.prank(user1);
         vm.expectRevert("Ownable: caller is not the owner");
-        token.addApprovedAccount(user1);
+        token.addMinterRole(user1);
     }
 
-    function test__NonOwnerCannotRemoveApprovedAccount() external {
-        token.addApprovedAccount(user1);
-        
+    function test__NonOwnerCannotRemoveMinterRole() external {
+        token.addMinterRole(user1);
+
         vm.prank(user1);
         vm.expectRevert("Ownable: caller is not the owner");
-        token.removeApprovedAccount(user1);
+        token.removeMinterRole(user1);
     }
 
-    function test__CannotAddAlreadyApprovedAccount() external {
-        token.addApprovedAccount(user1);
-        
-        vm.expectRevert(abi.encodeWithSelector(AccountAlreadyApproved.selector));
-        token.addApprovedAccount(user1);
+    function test__CannotAddAlreadyMinterRole() external {
+        token.addMinterRole(user1);
+
+        vm.expectRevert(abi.encodeWithSelector(AccountAlreadyMinter.selector));
+        token.addMinterRole(user1);
     }
 
-    function test__CannotRemoveNonApprovedAccount() external {
-        vm.expectRevert(abi.encodeWithSelector(AccountNotInList.selector));
-        token.removeApprovedAccount(user1);
+    function test__CannotRemoveNonMinterRole() external {
+        vm.expectRevert(abi.encodeWithSelector(AccountNotInMinterList.selector));
+        token.removeMinterRole(user1);
     }
 
-    function test__ApprovedAccountCanMint() external {
+    function test__MinterRoleCanMint() external {
         uint256 mintAmount = 1000 ether;
-        token.addApprovedAccount(user1);
-        
+        token.addMinterRole(user1);
+
         vm.prank(user1);
         token.mint(user2, mintAmount);
-        
+
         assertEq(token.balanceOf(user2), mintAmount);
     }
 
-    function test__NonApprovedNonOwnerAccountCannotMint() external {
+    function test__NonMinterNonOwnerAccountCannotMint() external {
         uint256 mintAmount = 1000 ether;
-        
-        vm.prank(nonApproved);
-        vm.expectRevert(abi.encodeWithSelector(AccountNotApproved.selector));
+
+        vm.prank(nonMinter);
+        vm.expectRevert(abi.encodeWithSelector(AccountNotMinter.selector));
         token.mint(user1, mintAmount);
     }
 
-    function test__MultipleApprovedAccountsCanMint() external {
+    function test__MultipleMinterRolesCanMint() external {
         uint256 mintAmount = 500 ether;
-        token.addApprovedAccount(user1);
-        token.addApprovedAccount(user2);
-        
+        token.addMinterRole(user1);
+        token.addMinterRole(user2);
+
         vm.prank(user1);
         token.mint(owner, mintAmount);
-        
+
         vm.prank(user2);
         token.mint(owner, mintAmount);
-        
+
         assertEq(token.balanceOf(owner), mintAmount * 2);
     }
 
-    function test__RemovedAccountCannotMint() external {
+    function test__RemovedMinterRoleCannotMint() external {
         uint256 mintAmount = 1000 ether;
-        token.addApprovedAccount(user1);
-        token.removeApprovedAccount(user1);
-        
+        token.addMinterRole(user1);
+        token.removeMinterRole(user1);
+
         vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSelector(AccountNotApproved.selector));
+        vm.expectRevert(abi.encodeWithSelector(AccountNotMinter.selector));
         token.mint(user2, mintAmount);
     }
 
-    function test__OwnerCanAlwaysMintEvenWhenNotApproved() external {
+    function test__OwnerCanAlwaysMintEvenWithoutMinterRole() external {
         uint256 mintAmount = 500 ether;
-        
-        // Owner is not in approved accounts but should still be able to mint
-        assertFalse(token.approvedAccounts(address(this)));
+
+        // Owner is not in minter role but should still be able to mint
+        assertFalse(token.minterRole(address(this)));
         token.mint(user1, mintAmount);
         assertEq(token.balanceOf(user1), mintAmount);
     }
 
-    function test__CheckApprovedAccountsMapping() external {
-        assertFalse(token.approvedAccounts(user1));
-        assertFalse(token.approvedAccounts(user2));
-        
-        token.addApprovedAccount(user1);
-        assertTrue(token.approvedAccounts(user1));
-        assertFalse(token.approvedAccounts(user2));
-        
-        token.addApprovedAccount(user2);
-        assertTrue(token.approvedAccounts(user1));
-        assertTrue(token.approvedAccounts(user2));
-        
-        token.removeApprovedAccount(user1);
-        assertFalse(token.approvedAccounts(user1));
-        assertTrue(token.approvedAccounts(user2));
+    function test__CheckMinterRoleMapping() external {
+        assertFalse(token.minterRole(user1));
+        assertFalse(token.minterRole(user2));
+
+        token.addMinterRole(user1);
+        assertTrue(token.minterRole(user1));
+        assertFalse(token.minterRole(user2));
+
+        token.addMinterRole(user2);
+        assertTrue(token.minterRole(user1));
+        assertTrue(token.minterRole(user2));
+
+        token.removeMinterRole(user1);
+        assertFalse(token.minterRole(user1));
+        assertTrue(token.minterRole(user2));
     }
 
     function test__ERC20BasicFunctionality() external {
-        token.addApprovedAccount(user1);
+        token.addMinterRole(user1);
         uint256 mintAmount = 1000 ether;
-        
+
         vm.prank(user1);
         token.mint(user2, mintAmount);
-        
+
         assertEq(token.balanceOf(user2), mintAmount);
         assertEq(token.totalSupply(), mintAmount);
-        
+
         vm.prank(user2);
         token.transfer(owner, 200 ether);
-        
+
         assertEq(token.balanceOf(user2), 800 ether);
         assertEq(token.balanceOf(owner), 200 ether);
     }
-
 }

--- a/test/TestStableToken.t.sol
+++ b/test/TestStableToken.t.sol
@@ -158,16 +158,16 @@ contract TestStableTokenTest is Test {
     function test__MinterAddedEventEmitted() external {
         vm.expectEmit(true, true, false, false);
         emit MinterAdded(user1);
-        
+
         token.addMinter(user1);
     }
 
     function test__MinterRemovedEventEmitted() external {
         token.addMinter(user1);
-        
+
         vm.expectEmit(true, true, false, false);
         emit MinterRemoved(user1);
-        
+
         token.removeMinter(user1);
     }
 

--- a/test/TestStableToken.t.sol
+++ b/test/TestStableToken.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import { Test } from "forge-std/Test.sol";
+import { TestStableToken, AccountNotApproved, AccountAlreadyApproved, AccountNotInList } from "./TestStableToken.sol";
+
+contract TestStableTokenTest is Test {
+    TestStableToken internal token;
+    address internal owner;
+    address internal user1;
+    address internal user2;
+    address internal nonApproved;
+
+    function setUp() public {
+        token = new TestStableToken();
+        owner = address(this);
+        user1 = vm.addr(1);
+        user2 = vm.addr(2);
+        nonApproved = vm.addr(3);
+    }
+
+    function test__OwnerCanAddApprovedAccount() external {
+        assertFalse(token.approvedAccounts(user1));
+        
+        token.addApprovedAccount(user1);
+        
+        assertTrue(token.approvedAccounts(user1));
+    }
+
+    function test__OwnerCanRemoveApprovedAccount() external {
+        token.addApprovedAccount(user1);
+        assertTrue(token.approvedAccounts(user1));
+        
+        token.removeApprovedAccount(user1);
+        
+        assertFalse(token.approvedAccounts(user1));
+    }
+
+    function test__OwnerCanMintWithoutApproval() external {
+        uint256 mintAmount = 1000 ether;
+        
+        token.mint(user1, mintAmount);
+        
+        assertEq(token.balanceOf(user1), mintAmount);
+    }
+
+    function test__NonOwnerCannotAddApprovedAccount() external {
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        token.addApprovedAccount(user1);
+    }
+
+    function test__NonOwnerCannotRemoveApprovedAccount() external {
+        token.addApprovedAccount(user1);
+        
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        token.removeApprovedAccount(user1);
+    }
+
+    function test__CannotAddAlreadyApprovedAccount() external {
+        token.addApprovedAccount(user1);
+        
+        vm.expectRevert(abi.encodeWithSelector(AccountAlreadyApproved.selector));
+        token.addApprovedAccount(user1);
+    }
+
+    function test__CannotRemoveNonApprovedAccount() external {
+        vm.expectRevert(abi.encodeWithSelector(AccountNotInList.selector));
+        token.removeApprovedAccount(user1);
+    }
+
+    function test__ApprovedAccountCanMint() external {
+        uint256 mintAmount = 1000 ether;
+        token.addApprovedAccount(user1);
+        
+        vm.prank(user1);
+        token.mint(user2, mintAmount);
+        
+        assertEq(token.balanceOf(user2), mintAmount);
+    }
+
+    function test__NonApprovedNonOwnerAccountCannotMint() external {
+        uint256 mintAmount = 1000 ether;
+        
+        vm.prank(nonApproved);
+        vm.expectRevert(abi.encodeWithSelector(AccountNotApproved.selector));
+        token.mint(user1, mintAmount);
+    }
+
+    function test__MultipleApprovedAccountsCanMint() external {
+        uint256 mintAmount = 500 ether;
+        token.addApprovedAccount(user1);
+        token.addApprovedAccount(user2);
+        
+        vm.prank(user1);
+        token.mint(owner, mintAmount);
+        
+        vm.prank(user2);
+        token.mint(owner, mintAmount);
+        
+        assertEq(token.balanceOf(owner), mintAmount * 2);
+    }
+
+    function test__RemovedAccountCannotMint() external {
+        uint256 mintAmount = 1000 ether;
+        token.addApprovedAccount(user1);
+        token.removeApprovedAccount(user1);
+        
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(AccountNotApproved.selector));
+        token.mint(user2, mintAmount);
+    }
+
+    function test__OwnerCanAlwaysMintEvenWhenNotApproved() external {
+        uint256 mintAmount = 500 ether;
+        
+        // Owner is not in approved accounts but should still be able to mint
+        assertFalse(token.approvedAccounts(address(this)));
+        token.mint(user1, mintAmount);
+        assertEq(token.balanceOf(user1), mintAmount);
+    }
+
+    function test__CheckApprovedAccountsMapping() external {
+        assertFalse(token.approvedAccounts(user1));
+        assertFalse(token.approvedAccounts(user2));
+        
+        token.addApprovedAccount(user1);
+        assertTrue(token.approvedAccounts(user1));
+        assertFalse(token.approvedAccounts(user2));
+        
+        token.addApprovedAccount(user2);
+        assertTrue(token.approvedAccounts(user1));
+        assertTrue(token.approvedAccounts(user2));
+        
+        token.removeApprovedAccount(user1);
+        assertFalse(token.approvedAccounts(user1));
+        assertTrue(token.approvedAccounts(user2));
+    }
+
+    function test__ERC20BasicFunctionality() external {
+        token.addApprovedAccount(user1);
+        uint256 mintAmount = 1000 ether;
+        
+        vm.prank(user1);
+        token.mint(user2, mintAmount);
+        
+        assertEq(token.balanceOf(user2), mintAmount);
+        assertEq(token.totalSupply(), mintAmount);
+        
+        vm.prank(user2);
+        token.transfer(owner, 200 ether);
+        
+        assertEq(token.balanceOf(user2), 800 ether);
+        assertEq(token.balanceOf(owner), 200 ether);
+    }
+
+}

--- a/test/WakuRlnV2.t.sol
+++ b/test/WakuRlnV2.t.sol
@@ -763,39 +763,6 @@ contract WakuRlnV2Test is Test {
         }
     }
 
-    function test__TestStableToken__OnlyOwnerCanMint() external {
-        address nonOwner = vm.addr(1);
-        uint256 mintAmount = 1000 ether;
-
-        vm.prank(nonOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
-        token.mint(nonOwner, mintAmount);
-    }
-
-    function test__TestStableToken__OwnerMintsTransfersAndRegisters() external {
-        address recipient = vm.addr(2);
-        uint256 idCommitment = 3;
-        uint32 membershipRateLimit = w.minMembershipRateLimit();
-        (, uint256 price) = w.priceCalculator().calculate(membershipRateLimit);
-
-        // Owner (test contract) mints tokens to recipient
-        token.mint(recipient, price);
-        assertEq(token.balanceOf(recipient), price);
-
-        // Recipient uses tokens to register
-        vm.startPrank(recipient);
-        token.approve(address(w), price);
-        w.register(idCommitment, membershipRateLimit, noIdCommitmentsToErase);
-        vm.stopPrank();
-
-        // Verify registration succeeded
-        assertTrue(w.isInMembershipSet(idCommitment));
-        (,,,, uint32 fetchedMembershipRateLimit, uint32 index, address holder,) = w.memberships(idCommitment);
-        assertEq(fetchedMembershipRateLimit, membershipRateLimit);
-        assertEq(holder, recipient);
-        assertEq(index, 0);
-    }
-
     function test__Upgrade() external {
         address testImpl = address(new WakuRlnV2());
         bytes memory data = abi.encodeCall(WakuRlnV2.initialize, (address(0), 100, 1, 10, 10 minutes, 4 minutes));


### PR DESCRIPTION
## Description

This work is related to making minting of tokens for RLN Deposits permissioned (https://github.com/waku-org/pm/issues/334).
This PR adds a modifier to the TestStableToken contract to allow for accounts added to the minterRole list to be allowed to mint tokens in addition to the contract owner.

There are now 2 roles:
`OWNER` - the contract owner account which has permission to execute all functions
`MINTER_ROLE` - accounts in the minterRole list that are allowed to mint tokens

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added minterRole mapping
- [x] Add functions to add or remove minters
- [x] Add errors for minter and non-minter accounts
- [x] Add test contract for TST
- [x] Update WakuRlnv2 test contract to remove token specific tests
