### PR TITLE
Use ERC20CappedUpgradeable template for token max supply

### DIFF
--- a/script/DeployTokenWithProxy.s.sol
+++ b/script/DeployTokenWithProxy.s.sol
@@ -14,9 +14,6 @@ contract DeployTokenWithProxy is BaseScript {
         // Read desired max supply from env or use default
         uint256 defaultMaxSupply = vm.envOr({ name: "MAX_SUPPLY", defaultValue: uint256(1_000_000 * 10 ** 18) });
 
-        // Validate value is sensible
-        require(defaultMaxSupply > 0, "MAX_SUPPLY must be > 0");
-
         // Deploy the initial implementation
         address implementation = address(new TestStableToken());
 

--- a/script/DeployTokenWithProxy.s.sol
+++ b/script/DeployTokenWithProxy.s.sol
@@ -11,14 +11,14 @@ contract DeployTokenWithProxy is BaseScript {
     }
 
     function deploy() public returns (ERC1967Proxy) {
-        // Read desired max supply from env or use default
-        uint256 defaultMaxSupply = vm.envOr({ name: "MAX_SUPPLY", defaultValue: uint256(1_000_000 * 10 ** 18) });
+        // Read desired token cap from env or use default
+        uint256 defaultCap = vm.envOr({ name: "TOKEN_CAP", defaultValue: uint256(1_000_000 * 10 ** 18) });
 
         // Deploy the initial implementation
         address implementation = address(new TestStableToken());
 
-        // Encode the initialize call (maxSupply)
-        bytes memory initData = abi.encodeCall(TestStableToken.initialize, (defaultMaxSupply));
+        // Encode the initialize call (cap)
+        bytes memory initData = abi.encodeCall(TestStableToken.initialize, (defaultCap));
 
         // Deploy the proxy with initialization data
         ERC1967Proxy proxy = new ERC1967Proxy(implementation, initData);
@@ -27,9 +27,9 @@ contract DeployTokenWithProxy is BaseScript {
         // These revert the script if validation fails.
         address proxyAddr = address(proxy);
 
-        // Check maxSupply set
-        uint256 actualMax = TestStableToken(proxyAddr).maxSupply();
-        if (actualMax != defaultMaxSupply) revert("Proxy maxSupply mismatch after initialization");
+        // Check cap set
+        uint256 actualMax = TestStableToken(proxyAddr).cap();
+        if (actualMax != defaultCap) revert("Proxy token cap mismatch after initialization");
 
         return proxy;
     }

--- a/test/README.md
+++ b/test/README.md
@@ -21,7 +21,8 @@ token distribution while mimicking DAI's behaviour.
 
 ## Usage
 
-Add environment variable `MAX_SUPPLY` to set the maximum supply of the token, otherwise it defaults to 10 million tokens.
+Add environment variable `MAX_SUPPLY` to set the maximum supply of the token, otherwise it defaults to 10 million
+tokens.
 
 ### Deploy new TestStableToken with proxy contract
 

--- a/test/README.md
+++ b/test/README.md
@@ -81,8 +81,10 @@ cast send $TOKEN_PROXY_ADDRESS "mint(address,uint256)" <TO_ADDRESS> <AMOUNT> --r
 
 #### Option 2: Public minting by burning ETH (no privileges required)
 
+The total tokens minted is determined by the amount of ETH sent with the transaction.
+
 ```bash
-cast send $TOKEN_PROXY_ADDRESS "mintWithETH(address,uint256)" <TO_ACCOUNT> <AMOUNT> --value <ETH_AMOUNT> --rpc-url $RPC_URL --private-key $MINTING_ACCOUNT_PRIVATE_KEY --from $MINTING_ACCOUNT_ADDRESS
+cast send $TOKEN_PROXY_ADDRESS "mintWithETH(address)" <TO_ACCOUNT> --value <ETH_AMOUNT> --rpc-url $RPC_URL --private-key $MINTING_ACCOUNT_PRIVATE_KEY --from $MINTING_ACCOUNT_ADDRESS
 ```
 
 **Note**: The `mintWithETH` function is public and can be called by anyone. It requires sending ETH with the transaction

--- a/test/README.md
+++ b/test/README.md
@@ -21,8 +21,7 @@ token distribution while mimicking DAI's behaviour.
 
 ## Usage
 
-Add environment variable `TOKEN_CAP` to set the maximum supply of the token, otherwise it defaults to 1 million
-tokens.
+Add environment variable `TOKEN_CAP` to set the maximum supply of the token, otherwise it defaults to 1 million tokens.
 
 ### Deploy new TestStableToken with proxy contract
 

--- a/test/README.md
+++ b/test/README.md
@@ -21,7 +21,7 @@ token distribution while mimicking DAI's behaviour.
 
 ## Usage
 
-Add environment variable `MAX_SUPPLY` to set the maximum supply of the token, otherwise it defaults to 10 million
+Add environment variable `TOKEN_CAP` to set the maximum supply of the token, otherwise it defaults to 1 million
 tokens.
 
 ### Deploy new TestStableToken with proxy contract
@@ -54,7 +54,7 @@ When upgrading a UUPS/ERC1967 proxy you should perform the upgrade and initializ
 leaving the proxy in an uninitialized state. Use `upgradeToAndCall(address,bytes)` with the initializer calldata.
 
 ```bash
-# Encode the initializer calldata (example: set MAX_SUPPLY to 1_000_000 * 10**18)
+# Encode the initializer calldata (example: set TOKEN_CAP to 1_000_000 * 10**18)
 DATA=$(cast abi-encode "initialize(uint256)" 1000000000000000000000000)
 
 # Perform upgrade and call initializer atomically
@@ -63,7 +63,7 @@ cast send $TOKEN_PROXY_ADDRESS "upgradeToAndCall(address,bytes)" $NEW_IMPLEMENTA
 
 If you must call `upgradeTo` separately (not recommended), follow up immediately with an `initialize(...)` call in the
 same transaction or as the next transaction from the owner/multisig. However, prefer `upgradeToAndCall` to eliminate the
-time window where the proxy points to a new implementation but its storage (e.g., `maxSupply`) is uninitialized.
+time window where the proxy points to a new implementation but its storage (e.g., `cap`) is uninitialized.
 
 ### Add account to the allowlist to enable minting
 

--- a/test/README.md
+++ b/test/README.md
@@ -47,7 +47,18 @@ implementation.
 ETH_FROM=$DEPLOYER_ACCOUNT_ADDRESS forge script test/TestStableToken.sol:TestStableTokenFactory --tc TestStableTokenFactory --rpc-url $RPC_URL --private-key $DEPLOYER_ACCOUNT_PRIVATE_KEY --broadcast
 ```
 
-### Update the proxy contract to point to the new implementation (safe, recommended)
+### Update the proxy contract to point to the new implementation
+
+#### Option 1: Update proxy implementation address only (recommended when the cap is already set)
+
+When the proxy is already initialized and the `cap` is set, you can simply update the implementation address using
+`upgradeTo(address)`.
+
+```bash
+cast send $TOKEN_PROXY_ADDRESS "upgradeTo(address)" $NEW_IMPLEMENTATION_ADDRESS --rpc-url $RPC_URL --private-key $DEPLOYER_ACCOUNT_PRIVATE_KEY
+```
+
+#### Option 2: Update proxy implementation address and initialize cap
 
 When upgrading a UUPS/ERC1967 proxy you should perform the upgrade and initialization in the same transaction to avoid
 leaving the proxy in an uninitialized state. Use `upgradeToAndCall(address,bytes)` with the initializer calldata.

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -15,6 +15,7 @@ error AccountAlreadyMinter();
 error AccountNotInMinterList();
 error InsufficientETH();
 error ExceedsMaxSupply();
+error InvalidMaxSupply(uint256 supplied);
 
 contract TestStableToken is
     Initializable,
@@ -45,6 +46,7 @@ contract TestStableToken is
         __ERC20Permit_init("TestStableToken");
         __Ownable_init();
         __UUPSUpgradeable_init();
+        if (_maxSupply == 0) revert InvalidMaxSupply(_maxSupply);
 
         maxSupply = _maxSupply;
     }
@@ -96,9 +98,6 @@ contract TestStableTokenFactory is BaseScript {
     function run() public broadcast returns (address) {
         // Read desired max supply from env or use default
         uint256 defaultMaxSupply = vm.envOr({ name: "MAX_SUPPLY", defaultValue: uint256(1_000_000 * 10 ** 18) });
-
-        // Validate value is sensible
-        if (defaultMaxSupply == 0) revert("MAX_SUPPLY must be > 0");
 
         // Deploy the implementation
         address implementation = address(new TestStableToken());

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -118,8 +118,6 @@ contract TestStableToken is
 }
 
 contract TestStableTokenFactory is BaseScript {
-    // Use the returned implementation address with a proxy upgrade call (e.g. `upgradeToAndCall`) to atomically point a
-    // proxy to the new implementation and initialize it.
     function run() public broadcast returns (address) {
         return address(new TestStableToken());
     }

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -118,21 +118,9 @@ contract TestStableToken is
 }
 
 contract TestStableTokenFactory is BaseScript {
-    /// @notice Deploys the implementation and an ERC1967 proxy, initializing the proxy atomically.
-    /// @dev Reads `TOKEN_CAP` from environment (wei). Defaults to 1_000_000 * 10**18.
+    // Use the returned implementation address with a proxy upgrade call (e.g. `upgradeToAndCall`) to atomically point a
+    // proxy to the new implementation and initialize it.
     function run() public broadcast returns (address) {
-        // Read desired token cap from env or use default
-        uint256 defaultCap = vm.envOr({ name: "TOKEN_CAP", defaultValue: uint256(1_000_000 * 10 ** 18) });
-
-        // Deploy the implementation
-        address implementation = address(new TestStableToken());
-
-        // Encode initializer calldata to run in proxy context (cap)
-        bytes memory initData = abi.encodeCall(TestStableToken.initialize, (defaultCap));
-
-        // Deploy ERC1967Proxy with initialization data so storage (owner, cap) is set atomically
-        ERC1967Proxy proxy = new ERC1967Proxy(implementation, initData);
-
-        return address(proxy);
+        return address(new TestStableToken());
     }
 }

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -10,7 +10,6 @@ import { ERC20CappedUpgradeable } from
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 error AccountNotMinter();
 error AccountAlreadyMinter();

--- a/test/TestStableToken.sol
+++ b/test/TestStableToken.sol
@@ -103,14 +103,11 @@ contract TestStableTokenFactory is BaseScript {
         // Deploy the implementation
         address implementation = address(new TestStableToken());
 
-    // Encode initializer calldata to run in proxy context (maxSupply)
-    bytes memory initData = abi.encodeCall(TestStableToken.initialize, (defaultMaxSupply));
+        // Encode initializer calldata to run in proxy context (maxSupply)
+        bytes memory initData = abi.encodeCall(TestStableToken.initialize, (defaultMaxSupply));
 
         // Deploy ERC1967Proxy with initialization data so storage (owner, maxSupply) is set atomically
         ERC1967Proxy proxy = new ERC1967Proxy(implementation, initData);
-
-        // // Only check maxSupply was initialized; owner checks are optional for basic deployments
-        // address proxyAddr = address(proxy);
 
         return address(proxy);
     }

--- a/test/TestStableToken.t.sol
+++ b/test/TestStableToken.t.sol
@@ -8,7 +8,8 @@ import {
     AccountAlreadyMinter,
     AccountNotInMinterList,
     InsufficientETH,
-    ExceedsMaxSupply
+    ExceedsMaxSupply,
+    InvalidMaxSupply
 } from "./TestStableToken.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { DeployTokenWithProxy } from "../script/DeployTokenWithProxy.s.sol";
@@ -335,5 +336,19 @@ contract TestStableTokenTest is Test {
         vm.prank(user1);
         vm.expectRevert("Ownable: caller is not the owner");
         token.setMaxSupply(newMaxSupply);
+    }
+
+    function test__InitializeZeroReverts() external {
+        // Deploy implementation directly
+        TestStableToken implementation = new TestStableToken();
+
+        // Build initializer calldata with zero
+        bytes memory initData = abi.encodeCall(TestStableToken.initialize, (uint256(0)));
+
+        // Expect the InvalidMaxSupply reversion including the supplied value
+        vm.expectRevert(abi.encodeWithSelector(InvalidMaxSupply.selector, uint256(0)));
+
+        // Attempt to deploy proxy with initData - should revert
+        new ERC1967Proxy(address(implementation), initData);
     }
 }


### PR DESCRIPTION
## Description

This is the same goal as this PR https://github.com/waku-org/waku-rlnv2-contract/pull/37 to implement a max supply of tokens that can be minted, but this uses the OpenZeppelin template instead of implementing it manually.
