### PR TITLE
Add root storage cache

### DIFF
--- a/src/WakuRlnV2.sol
+++ b/src/WakuRlnV2.sol
@@ -37,6 +37,10 @@ contract WakuRlnV2 is Initializable, OwnableUpgradeable, UUPSUpgradeable, Member
     /// @notice The Merkle tree that stores rate commitments of memberships
     LazyIMTData public merkleTree;
 
+    /// @notice Emitted whenever a new Merkle tree root is stored
+    /// @param newRoot The newly stored Merkle tree root
+    event RootStored(uint256 newRoot);
+
     /// @notice Сheck if the idCommitment is valid
     /// @param idCommitment The idCommitment of the membership
     modifier onlyValidIdCommitment(uint256 idCommitment) {
@@ -59,6 +63,7 @@ contract WakuRlnV2 is Initializable, OwnableUpgradeable, UUPSUpgradeable, Member
 
     // Fixed-size circular buffer for recent roots
     uint8 public constant HISTORY_SIZE = 5;
+
     /// @notice Fixed-size circular buffer storing the most recent HISTORY_SIZE roots
     /// @dev Organized as a ring buffer where rootIndex points to the next write position
     uint256[HISTORY_SIZE] private recentRoots;
@@ -203,6 +208,8 @@ contract WakuRlnV2 is Initializable, OwnableUpgradeable, UUPSUpgradeable, Member
             recentRoots[rootIndex] = newRoot;
             rootIndex = (rootIndex + 1) % HISTORY_SIZE;
         }
+
+        emit RootStored(newRoot);
     }
 
     /// @notice Returns the list of recent roots, newest first


### PR DESCRIPTION
## Description

This PR is to implement a root storage cache of most recent roots, that can be used by nodes to generate and verify proofs. This implementation will allow for the function caller to reduce the number of web RPC calls to the contract while still having a history of roots to use for validation.

This PR is part of completing https://github.com/waku-org/research/issues/116.
This is phase 1 and the next step is to implement the changes in nwaku to use the returned array of roots instead of a singular latest root.

Fixed array is used for optimized gas usage.
The fixed storage size of `HISTORY_SIZE=5` is a temporary value for now - we need to run simulations to determine what size storage is ideal.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
